### PR TITLE
Merge `release/0.3.0` back into `develop`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "home-assistant"
-version = "0.2.1"
+version = "0.3.0"
 description = ""
 authors = ["Will Garside <worgarside@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
- Release 0.2.0 (#164)
- Bump to 0.2.1
- Fix bug with release GHAs
- Fix another release GHA bug
- Bump to 0.3.0
