### PR TITLE
Release 2.0.0

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -8,6 +8,6 @@ jobs:
   create-new-release:
     name: Create New Release
     # yamllint disable-line rule:line-length
-    uses: worgarside/github-config-files/.github/workflows/create_new_release.yml@feature/create-new-release-gha
+    uses: worgarside/github-config-files/.github/workflows/create_new_release.yml@main
     secrets:
       gh-token: ${{ secrets.WORGARSIDE_DEV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "home-assistant"
-version = "1.0.0"
+version = "2.0.0"
 description = ""
 authors = ["Will Garside <worgarside@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
- Update release creator workflow to point at `main` (#324)
- Bump version to 2.0.0
