### PR TITLE
Bump `worgarside/home-assistant-appdaemon` to `0.1.0`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,7 +47,10 @@ labels:
 
   - label: ha:appdaemon
     files:
-      - ^appdaemon/.+$
+      - ^appdaemon.+$
+
+  - label: ha:appdaemon
+    title: ^.+appdaemon.+
 
   - label: ha:automations
     files:


### PR DESCRIPTION

- 7960a76 | Bump `worgarside/home-assistant-appdaemon` to `0.1.0`
- 63241ef | Update auto-labeler
