### PR TITLE
Remove deleted AppDaemon Git sensor references

### DIFF
--- a/entities/automation/input_boolean/system/latest_release_downloaded/on.yaml
+++ b/entities/automation/input_boolean/system/latest_release_downloaded/on.yaml
@@ -12,5 +12,3 @@ action:
       entity_id:
         - sensor.current_git_branch
         - sensor.current_git_ref
-        - sensor.current_appdaemon_ref
-        - sensor.current_appdaemon_branch


### PR DESCRIPTION

- d015d0e | Remove deleted AppDaemon Git sensor references
