### PR TITLE
Remove fragile sensors for MacBook updates

### DIFF
--- a/entities/template/sensor/st_macbook_pro_last_update.yaml
+++ b/entities/template/sensor/st_macbook_pro_last_update.yaml
@@ -13,7 +13,6 @@ state: >
       states.sensor.st_macbook_pro_connection_type.last_updated,
       states.sensor.st_macbook_pro_displays.last_updated,
       states.sensor.st_macbook_pro_frontmost_app.last_updated,
-      states.sensor.st_macbook_pro_geocoded_location.last_updated,
       states.sensor.st_macbook_pro_internal_battery_level.last_updated,
       states.sensor.st_macbook_pro_internal_battery_state.last_updated,
       states.sensor.st_macbook_pro_last_update_trigger.last_updated,

--- a/entities/template/sensor/will_s_macbook_pro_last_update.yaml
+++ b/entities/template/sensor/will_s_macbook_pro_last_update.yaml
@@ -13,7 +13,6 @@ state: >
       states.sensor.wills_macbook_pro_connection_type.last_updated,
       states.sensor.wills_macbook_pro_displays.last_updated,
       states.sensor.wills_macbook_pro_frontmost_app.last_updated,
-      states.sensor.wills_macbook_pro_geocoded_location.last_updated,
       states.sensor.wills_macbook_pro_internal_battery_level.last_updated,
       states.sensor.wills_macbook_pro_internal_battery_state.last_updated,
       states.sensor.wills_macbook_pro_last_update_trigger.last_updated,


### PR DESCRIPTION

- 19ec092 | Remove fragile sensors for MacBook updates
