### PR TITLE
Update Topaz SR10 timeout to check for active use, not just connection

### DIFF
--- a/entities/automation/media_player/topaz_sr10/timeout.yaml
+++ b/entities/automation/media_player/topaz_sr10/timeout.yaml
@@ -18,7 +18,7 @@ trigger:
 
 condition:
   or:
-    - alias: Source is MacBook, but MacBook is not active=
+    - alias: Source is MacBook, but MacBook is not active
       and:
         - condition: state
           entity_id: input_select.topaz_sr10_source

--- a/entities/automation/media_player/topaz_sr10/timeout.yaml
+++ b/entities/automation/media_player/topaz_sr10/timeout.yaml
@@ -27,10 +27,10 @@ condition:
         - condition: template
           value_template: >-
             {{
-                "FiiO USB DAC-E10" not in [
-                  states("sensor.st_macbook_pro_active_audio_output"),
-                  states("sensor.wills_macbook_pro_active_audio_output")
-                ]
+              "FiiO USB DAC-E10" not in [
+                states("sensor.st_macbook_pro_active_audio_output"),
+                states("sensor.wills_macbook_pro_active_audio_output")
+              ]
             }}
 
     - alias: Some other source selected (specifics to be added when needed)

--- a/entities/automation/media_player/topaz_sr10/timeout.yaml
+++ b/entities/automation/media_player/topaz_sr10/timeout.yaml
@@ -18,7 +18,8 @@ trigger:
 
 condition:
   or:
-    - and:
+    - alias: Source is MacBook, but MacBook is not active=
+      and:
         - condition: state
           entity_id: input_select.topaz_sr10_source
           state: MP3/Aux
@@ -26,13 +27,14 @@ condition:
         - condition: template
           value_template: >-
             {{
-              "FiiO USB DAC-E10" not in (
-                state_attr("sensor.wills_macbook_pro_active_audio_output", "All Audio Output") +
-                state_attr("sensor.st_macbook_pro_active_audio_output", "All Audio Output")
-              )
+                "FiiO USB DAC-E10" not in [
+                  states("sensor.st_macbook_pro_active_audio_output"),
+                  states("sensor.wills_macbook_pro_active_audio_output")
+                ]
             }}
 
-    - not:
+    - alias: Some other source selected (specifics to be added when needed)
+      not:
         - condition: state
           entity_id: input_select.topaz_sr10_source
           state: MP3/Aux

--- a/entities/automation/media_player/topaz_sr10/timeout.yaml
+++ b/entities/automation/media_player/topaz_sr10/timeout.yaml
@@ -28,8 +28,8 @@ condition:
           value_template: >-
             {{
               "FiiO USB DAC-E10" not in [
+                states("sensor.wills_macbook_pro_active_audio_output"),
                 states("sensor.st_macbook_pro_active_audio_output"),
-                states("sensor.wills_macbook_pro_active_audio_output")
               ]
             }}
 


### PR DESCRIPTION

- 6cc1cb3 | Update Topaz SR10 timeout to check for active use, not just connection
- cd98c1a | Fix whitespace
- a125b74 | Change order
- b6f7e77 | Fix typo
