### PR TITLE
Fix Cosmo images reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,4 +350,4 @@ themes
 !entities/var/
 
 
-www/images/cosmo/*.webp
+www/images/cosmo/


### PR DESCRIPTION

- e2ddb94 | Fix Cosmo images reset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude all files in the `www/images/cosmo/` directory, enhancing file management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->