### PR TITLE
Make Topaz SR10 timeout configurable

### DIFF
--- a/entities/automation/media_player/topaz_sr10/timeout.yaml
+++ b/entities/automation/media_player/topaz_sr10/timeout.yaml
@@ -14,7 +14,7 @@ trigger:
     entity_id: media_player.topaz_sr10
     to: "on" # Other states are a definite "no"
     for:
-      minutes: 5
+      minutes: "{{ states('input_number.topaz_sr10_power_off_timeout') | int(30) }}"
 
 condition:
   or:

--- a/entities/input_number/topaz_sr10/topaz_sr10_power_off_timeout.yaml
+++ b/entities/input_number/topaz_sr10/topaz_sr10_power_off_timeout.yaml
@@ -1,0 +1,14 @@
+---
+icon: mdi:timer-music-outline
+
+max: 120
+
+min: 1
+
+mode: box
+
+name: Topaz SR10 | Power Off Timeout
+
+step: 1
+
+unit_of_measurement: minutes

--- a/entities/input_number/topaz_sr10/topaz_sr10_volume_level.yaml
+++ b/entities/input_number/topaz_sr10/topaz_sr10_volume_level.yaml
@@ -7,7 +7,7 @@ min: -80
 
 mode: box
 
-name: Topaz SR10 Volume Level
+name: Topaz SR10 | Volume Level
 
 step: 1
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2484,7 +2484,7 @@ File: [`input_datetime/pineapple_last_watered.yaml`](entities/input_datetime/pin
 
 ## Input Number
 
-<details><summary><h3>Entities (24)</h3></summary>
+<details><summary><h3>Entities (25)</h3></summary>
 
 <details><summary><strong>Auto-Save Debit Transaction Percentage</strong></summary>
 
@@ -2759,7 +2759,20 @@ File: [`input_number/st_macbook_pro_full_battery_threshold.yaml`](entities/input
 File: [`input_number/st_macbook_pro_low_battery_threshold.yaml`](entities/input_number/st_macbook_pro_low_battery_threshold.yaml)
 </details>
 
-<details><summary><strong>Topaz SR10 Volume Level</strong></summary>
+<details><summary><strong>Topaz SR10 | Power Off Timeout</strong></summary>
+
+**Entity ID: `input_number.topaz_sr10_power_off_timeout`**
+
+- Icon: [`mdi:timer-music-outline`](https://pictogrammers.com/library/mdi/icon/timer-music-outline/)
+- Max: 120
+- Min: 1
+- Mode: `box`
+- Unit Of Measurement: `minutes`
+
+File: [`input_number/topaz_sr10/topaz_sr10_power_off_timeout.yaml`](entities/input_number/topaz_sr10/topaz_sr10_power_off_timeout.yaml)
+</details>
+
+<details><summary><strong>Topaz SR10 | Volume Level</strong></summary>
 
 **Entity ID: `input_number.topaz_sr10_volume_level`**
 


### PR DESCRIPTION

- 99af92a | Make Topaz SR10 timeout configurable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic timeout setting for the Topaz SR10 media player, allowing users to adjust the power-off timeout.
  - Added a new configuration setting for the Topaz SR10 Power Off Timeout, enabling users to set a timeout value between 1 and 120 minutes.

- **Enhancements**
  - Updated the display name for the Topaz SR10 volume level setting to improve clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->