### PR TITLE
Add ESPHome config file for Bluetooth proxy

### DIFF
--- a/esphome/esp32-bluetooth-proxy.yaml
+++ b/esphome/esp32-bluetooth-proxy.yaml
@@ -11,9 +11,6 @@ esphome:
   friendly_name: ${friendly_name}
 
 api:
-  encryption:
-    key: JKa5GXZhdKyjQ80VZn13SKA8KUUWcR7shKoJoZnM9NA=
-
 
 wifi:
   ssid: !secret wifi_ssid

--- a/esphome/esp32-bluetooth-proxy.yaml
+++ b/esphome/esp32-bluetooth-proxy.yaml
@@ -1,0 +1,20 @@
+substitutions:
+  name: esp32-bluetooth-proxy
+  friendly_name: Bluetooth Proxy (Office Desk)
+
+packages:
+  esphome.bluetooth-proxy: github://esphome/firmware/bluetooth-proxy/esp32-generic.yaml@main
+
+esphome:
+  name: ${name}
+  name_add_mac_suffix: false
+  friendly_name: ${friendly_name}
+
+api:
+  encryption:
+    key: JKa5GXZhdKyjQ80VZn13SKA8KUUWcR7shKoJoZnM9NA=
+
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/esphome/esp32-bluetooth-proxy.yaml
+++ b/esphome/esp32-bluetooth-proxy.yaml
@@ -1,3 +1,4 @@
+---
 substitutions:
   name: esp32-bluetooth-proxy
   friendly_name: Bluetooth Proxy (Office Desk)


### PR DESCRIPTION

- 0edcda2 | Add ESPHome config file for Bluetooth proxy
- 1c495d9 | Remove key
- 5d49a19 | [pre-commit.ci] auto fixes from pre-commit.com hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configuration for a Bluetooth proxy device named "Bluetooth Proxy (Office Desk)" with WiFi and API settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->