### PR TITLE
#940: Update Cosmo's nightly clean wait/delay logic

### DIFF
--- a/entities/automation/cosmo/nightly_kitchen_clean.yaml
+++ b/entities/automation/cosmo/nightly_kitchen_clean.yaml
@@ -7,24 +7,37 @@ mode: single
 
 trigger:
   platform: time
-  at: '22:00:00'
+  at: "22:00:00"
+
+variables:
+  carpet_boost: "{{ states('switch.cosmo_carpet_boost') }}"
+
+  lights_on: >-
+    {{
+      expand((area_entities('lounge') + area_entities('kitchen')) | select('match', '^light\.')) |
+      selectattr('state', 'eq', 'on') |
+      list |
+      count > 0
+    }}
 
 action:
-  - alias: Wait for lights out
-    wait_template: >-
-      {{
-        expand((area_entities('lounge') + area_entities('kitchen')) | select('match', '^light\.')) |
-        selectattr('state', 'eq', 'on') |
-        list |
-        count == 0
-      }}
-    # hacv disable: InvalidTemplateVar:area_entities,expand
+  - if: "{{ lights_on }}"
 
-  - delay:
-      minutes: 10
+    then:
+      - alias: Wait for lights out
+        timeout:
+          hours: 1
+        wait_template: >-
+          {{
+            expand((area_entities('lounge') + area_entities('kitchen')) |
+            select('match', '^light\.')) |
+            selectattr('state', 'eq', 'on') |
+            list |
+            count == 0
+          }}
 
-  - variables:
-      carpet_boost: "{{ states('switch.cosmo_carpet_boost') }}"
+      - delay:
+          minutes: 15
 
   - if: "{{ carpet_boost | bool }}"
     then:

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -137,7 +137,14 @@ File: [`automation/cosmo/clean_flat.yaml`](entities/automation/cosmo/clean_flat.
 - Alias: /cosmo/nightly-kitchen-clean
 - ID: `cosmo_nightly_kitchen_clean`
 - Mode: `single`
+- Variables:
 
+```json
+{
+  "carpet_boost": "{{ states('switch.cosmo_carpet_boost') }}",
+  "lights_on": "{{\n  expand((area_entities('lounge') + area_entities('kitchen')) | select('match', '^light\\.')) |\n  selectattr('state', 'eq', 'on') |\n  list |\n  count > 0\n}}"
+}
+```
 File: [`automation/cosmo/nightly_kitchen_clean.yaml`](entities/automation/cosmo/nightly_kitchen_clean.yaml)
 </details>
 


### PR DESCRIPTION
Resolves #940

---



- 8a8ef7b | #940: Update Cosmo's nightly clean wait/delay logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
  - Introduced a smart delay feature in the nightly kitchen clean automation, which waits for lights to go out and adds a 15-minute delay if lights were on.

- **Improvements**
  - Enhanced the logic to determine if lights are on in the lounge or kitchen, providing more accurate automation triggers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->