### PR TITLE
Ensure all special characters are escaped when writing a file

### DIFF
--- a/entities/shell_command/file_operations/write_file.yaml
+++ b/entities/shell_command/file_operations/write_file.yaml
@@ -1,3 +1,3 @@
 ---
 # yamllint disable rule:line-length
-write_file: bash -c "echo -e \"{{ body.replace('\"', '\\"').replace('\\', '\\\\') }}\" >> 'resources/tmp/{{ file.strip('/"') }}'"
+write_file: bash -c "echo -e \"{{ body.replace('\"', '\\"').replace('\\', '\\\\').replace("\'", "'\\'").replace('`', '\\`').replace('$', '\\$').replace('\n', '\\n').replace('&', '\\&').replace('|', '\\|').replace('<', '\\<').replace('>', '\\>').replace(';', '\\;').replace('*', '\\*').replace('?', '\\?').replace('[', '\\[').replace(']', '\\]') }}\" >> 'resources/tmp/{{ file.strip('/"') }}'"


### PR DESCRIPTION
Resolves #944

---



- 3092dd3 | Ensure all special characters are escaped when writing a file
