### PR TITLE
Add delays to protect Topaz SR10

### DIFF
--- a/entities/automation/media_player/topaz_sr10/on.yaml
+++ b/entities/automation/media_player/topaz_sr10/on.yaml
@@ -4,8 +4,8 @@ alias: /media-player/topaz-sr10/on
 id: media_player_topaz_sr10_on
 
 description: >-
-  Run when the Topaz SR10 is turned on, this ensures the plug is turned on and that the volume is
-  initialized to a reasonable level for the speakers.
+  Run when the Topaz SR10 media player entity is turned on, this ensures the plug is turned on and
+  that the volume is initialized to a reasonable level for the speakers.
 
 mode: single
 
@@ -30,7 +30,7 @@ action:
             entity_id: switch.office_amp
 
         - delay:
-            seconds: 1
+            seconds: 2
 
   - if: "{{ is_state('switch.office_amp', 'on') }}"
 

--- a/entities/automation/remote/office/hold.yaml
+++ b/entities/automation/remote/office/hold.yaml
@@ -1,13 +1,23 @@
 ---
 alias: /remote/office/hold
+
 id: remote_office_hold
+
 mode: single
+
+max_exceeded: silent
+
 trigger:
   - platform: event
     event_type: zha_event
     event_data:
       command: hold
       device_ieee: 00:15:8d:00:09:ee:31:98
+
 action:
   - service: switch.toggle
     entity_id: switch.office_amp
+
+  - alias: Prevent rapid toggling
+    delay:
+      seconds: 5

--- a/entities/script/media_player/topaz_sr10/topaz_sr10_turn_off.yaml
+++ b/entities/script/media_player/topaz_sr10/topaz_sr10_turn_off.yaml
@@ -1,7 +1,7 @@
 ---
 alias: "Topaz SR10: Turn Off"
 
-description: Set the volume of the Topaz SR10 to a specific value
+description: Turn the Topaz SR10 off. Exists as a script because you can't have multi-step commands
 
 mode: single
 
@@ -29,6 +29,19 @@ sequence:
             target:
               entity_id: media_player.topaz_sr10
             continue_on_error: true
+
+  - alias: Ensure it's been switched on for >5 seconds to avoid rapid power cycling
+    if: >-
+      {{
+        (
+          now() | as_timestamp(default=0) -
+          states.switch.office_amp.last_changed | as_timestamp(default=0)
+        ) | int(0) < 5
+      }}
+
+    then:
+      - delay:
+          seconds: 5
 
   - service: switch.turn_off
     target:

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -913,7 +913,7 @@ File: [`automation/media_player/topaz_sr10/off.yaml`](entities/automation/media_
 
 **Entity ID: `automation.media_player_topaz_sr10_on`**
 
-> Run when the Topaz SR10 is turned on, this ensures the plug is turned on and that the volume is initialized to a reasonable level for the speakers.
+> Run when the Topaz SR10 media player entity is turned on, this ensures the plug is turned on and that the volume is initialized to a reasonable level for the speakers.
 
 - Alias: /media-player/topaz-sr10/on
 - ID: `media_player_topaz_sr10_on`
@@ -4503,7 +4503,7 @@ File: [`script/light/kitchen_spotlights/turn_on_kitchen_spotlights.yaml`](entiti
 
 **Entity ID: `script.topaz_sr10_turn_off`**
 
-> Set the volume of the Topaz SR10 to a specific value
+> Turn the Topaz SR10 off. Exists as a script because you can't have multi-step commands
 
 - Mode: `single`
 


### PR DESCRIPTION


---



- a037d13 | Add delays to protect Topaz SR10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated description for the Topaz SR10 media player automation for better clarity.
  - Adjusted delay time from 1 to 2 seconds for Topaz SR10 media player automation.

- **New Features**
  - Added `max_exceeded` setting and a 5-second delay action in the remote office hold automation to prevent rapid toggling.
  - Implemented a delay to ensure the Topaz SR10 media player has been on for more than 5 seconds before turning off to prevent rapid power cycling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->