### PR TITLE
Add `var.auto_save_cumulative_total` for auto-saver tracking

### DIFF
--- a/entities/var/auto_save_amount.yaml
+++ b/entities/var/auto_save_amount.yaml
@@ -1,6 +1,10 @@
 ---
 friendly_name: Auto-Save Amount
+
 unit_of_measurement: GBP
+
 icon: mdi:piggy-bank
+
 restore: true
+
 unique_id: var_auto_save_amount

--- a/entities/var/auto_save_cumulative_total.yaml
+++ b/entities/var/auto_save_cumulative_total.yaml
@@ -1,0 +1,10 @@
+---
+friendly_name: Auto-Save Cumulative Total
+
+unit_of_measurement: GBP
+
+icon: mdi:chart-timeline-variant-shimmer
+
+restore: true
+
+unique_id: var_auto_save_cumulative_total

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -6161,7 +6161,7 @@ File: [`template_triggered/sensor/will_s_yas_209_bridge_input.yaml`](entities/te
 
 ## Var
 
-<details><summary><h3>Entities (15)</h3></summary>
+<details><summary><h3>Entities (16)</h3></summary>
 
 <details><summary><strong>Auto-Save Amount</strong></summary>
 
@@ -6171,6 +6171,16 @@ File: [`template_triggered/sensor/will_s_yas_209_bridge_input.yaml`](entities/te
 - Unit Of Measurement: GBP
 
 File: [`var/auto_save_amount.yaml`](entities/var/auto_save_amount.yaml)
+</details>
+
+<details><summary><strong>Auto-Save Cumulative Total</strong></summary>
+
+**Entity ID: `var.auto_save_cumulative_total`**
+
+- Icon: [`mdi:chart-timeline-variant-shimmer`](https://pictogrammers.com/library/mdi/icon/chart-timeline-variant-shimmer/)
+- Unit Of Measurement: GBP
+
+File: [`var/auto_save_cumulative_total.yaml`](entities/var/auto_save_cumulative_total.yaml)
 </details>
 
 <details><summary><strong>Boolean Flag: Kitchen Lights</strong></summary>


### PR DESCRIPTION


---



- 7f626bf | Add `var.auto_save_cumulative_total` for auto-saver tracking


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new attributes to the "Auto-Save Amount" entity, including unit of measurement (GBP), icon (piggy bank), and unique identifier.
  - Introduced a new entity named "Auto-Save Cumulative Total" with configuration for display name, unit of measurement (GBP), icon (chart timeline), and unique identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->