### PR TITLE
Add Bash & Python subshell shell commands

### DIFF
--- a/entities/shell_command/bash_subshell.yaml
+++ b/entities/shell_command/bash_subshell.yaml
@@ -1,0 +1,2 @@
+---
+bash_subshell: bash -c "{{ command }}"

--- a/entities/shell_command/python_subshell.yaml
+++ b/entities/shell_command/python_subshell.yaml
@@ -1,0 +1,2 @@
+---
+python_subshell: python -c "{{ command }}"

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5000,11 +5000,16 @@ File: [`sensor/tomorrow_io_realtime_weather.yaml`](entities/sensor/tomorrow_io_r
 
 ## Shell Command
 
-<details><summary><h3>Entities (15)</h3></summary>
+<details><summary><h3>Entities (17)</h3></summary>
 
 <details><summary><code>shell_command.approve_pull_request</code></summary>
 
 File: [`shell_command/approve_pull_request.yaml`](entities/shell_command/approve_pull_request.yaml)
+</details>
+
+<details><summary><code>shell_command.bash_subshell</code></summary>
+
+File: [`shell_command/bash_subshell.yaml`](entities/shell_command/bash_subshell.yaml)
 </details>
 
 <details><summary><code>shell_command.checkout_git_branch</code></summary>
@@ -5050,6 +5055,11 @@ File: [`shell_command/ls.yaml`](entities/shell_command/ls.yaml)
 <details><summary><code>shell_command.mark_pr_as_ready_for_review</code></summary>
 
 File: [`shell_command/mark_pr_as_ready_for_review.yaml`](entities/shell_command/mark_pr_as_ready_for_review.yaml)
+</details>
+
+<details><summary><code>shell_command.python_subshell</code></summary>
+
+File: [`shell_command/python_subshell.yaml`](entities/shell_command/python_subshell.yaml)
 </details>
 
 <details><summary><code>shell_command.run_custom_file_1</code></summary>


### PR DESCRIPTION


---



- 5eb94f8 | Add Bash & Python subshell shell commands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `bash_subshell` command to execute Bash subshells with specified commands.
	- Introduced `python_subshell` functionality to run Python commands in a subshell environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->