### PR TITLE
Fix/simplify `shell_command.write_file` escaping

### DIFF
--- a/entities/shell_command/file_operations/write_file.yaml
+++ b/entities/shell_command/file_operations/write_file.yaml
@@ -1,3 +1,3 @@
 ---
 # yamllint disable rule:line-length
-write_file: bash -c "echo -e \"{{ body.replace('\"', '\\"').replace('\\', '\\\\').replace("\'", "'\\'").replace('`', '\\`').replace('$', '\\$').replace('\n', '\\n').replace('&', '\\&').replace('|', '\\|').replace('<', '\\<').replace('>', '\\>').replace(';', '\\;').replace('*', '\\*').replace('?', '\\?').replace('[', '\\[').replace(']', '\\]') }}\" >> 'resources/tmp/{{ file.strip('/"') }}'"
+write_file: bash -c "echo -e \"{{ body.replace('"', '\"').replace('`', '\`').replace('\n', '\\n') }}\" >> 'resources/tmp/{{ file.strip('/"') }}'"


### PR DESCRIPTION


---



- c60a95a | Fix/simplify `shell_command.write_file` escaping
