### PR TITLE
Always overwrite file in `shell_command.write_file`

### DIFF
--- a/entities/shell_command/file_operations/write_file.yaml
+++ b/entities/shell_command/file_operations/write_file.yaml
@@ -1,3 +1,3 @@
 ---
 # yamllint disable rule:line-length
-write_file: bash -c "echo -e \"{{ body | base64_encode }}\" >> 'resources/tmp/{{ file.strip('/"') }}'"
+write_file: bash -c "echo -e \"{{ body | base64_encode }}\" > 'resources/tmp/{{ file.strip('/"') }}'"


### PR DESCRIPTION


---



- a4372da | Always overwrite file in `shell_command.write_file`
