### PR TITLE
Add MQTT `sensor.filament_type`

### DIFF
--- a/entities/mqtt/sensor/prusa_i3/filament_type.yaml
+++ b/entities/mqtt/sensor/prusa_i3/filament_type.yaml
@@ -1,0 +1,10 @@
+---
+force_update: false
+
+icon: mdi:printer-3d-nozzle
+
+name: Prusa i3 Filament Type
+
+state_topic: octoPrint/metadata/slicer_settings.filament_type
+
+unique_id: prusa_i3_filament_type

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -3034,7 +3034,7 @@ File: [`media_player/topaz_sr10.yaml`](entities/media_player/topaz_sr10.yaml)
 
 ## Mqtt
 
-<details><summary><h3>Entities (99)</h3></summary>
+<details><summary><h3>Entities (100)</h3></summary>
 
 <details><summary><strong>MtrxPi | Matrix: Brightness</strong></summary>
 
@@ -3849,6 +3849,16 @@ File: [`mqtt/sensor/octopi/memory_usage.yaml`](entities/mqtt/sensor/octopi/memor
 - Unit Of Measurement: `s`
 
 File: [`mqtt/sensor/octopi/uptime.yaml`](entities/mqtt/sensor/octopi/uptime.yaml)
+</details>
+
+<details><summary><strong>Prusa i3 Filament Type</strong></summary>
+
+**Entity ID: `sensor.prusa_i3_filament_type`**
+
+- Icon: [`mdi:printer-3d-nozzle`](https://pictogrammers.com/library/mdi/icon/printer-3d-nozzle/)
+- State Topic: octoPrint/metadata/slicer_settings.filament_type
+
+File: [`mqtt/sensor/prusa_i3/filament_type.yaml`](entities/mqtt/sensor/prusa_i3/filament_type.yaml)
 </details>
 
 <details><summary><strong>RtroPi Active Git Ref</strong></summary>


### PR DESCRIPTION


---



- dcbcc57 | Add MQTT `sensor.filament_type`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new sensor configuration for Prusa i3 Filament Type, providing detailed information about the filament type in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->