### PR TITLE
Don't turn OctoPi CPU fan off whilst printing

### DIFF
--- a/entities/automation/octopi/cpu_fan_control.yaml
+++ b/entities/automation/octopi/cpu_fan_control.yaml
@@ -17,10 +17,11 @@ variables:
 
 condition: >
   {{
-    (
-      is_state('switch.octopi_cpu_fan', "on") != should_be_on
-    ) and (
-      states.switch.octopi_cpu_fan.last_changed < ( utcnow() - timedelta(minutes=5) )
+    is_state("switch.octopi_cpu_fan", "on") != should_be_on and
+    states.switch.octopi_cpu_fan.last_changed < ( utcnow() - timedelta(minutes=5) )
+    and not (
+      states("sensor.octoprint_current_state") == "Printing" and
+      states("switch.octopi_cpu_fan") | bool
     )
   }}
 


### PR DESCRIPTION


---



- b9aa8c9 | Don't turn OctoPi CPU fan off whilst printing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CPU fan control logic in OctoPi setups by adding checks for the OctoPrint job state and CPU fan switch status. This ensures better fan management and efficiency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->