### PR TITLE
Add ESPHome moisture sensor config

### DIFF
--- a/esphome/.gitignore
+++ b/esphome/.gitignore
@@ -1,5 +1,0 @@
-# Gitignore settings for ESPHome
-# This is an example and may include too much for your use-case.
-# You can modify this file to suit your needs.
-/.esphome/
-/secrets.yaml

--- a/esphome/esp32-moisture-sensor.yaml
+++ b/esphome/esp32-moisture-sensor.yaml
@@ -1,0 +1,48 @@
+---
+substitutions:
+  name: soil-moisture-sensor
+  friendly_name: Soil Moisture Sensor
+
+esphome:
+  name: ${name}
+  name_add_mac_suffix: false
+  friendly_name: ${friendly_name}
+
+# https://learn.adafruit.com/adafruit-huzzah32-esp32-feather
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+api:
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+sensor:
+    # https://murt.is/articles/2021-02/huzzah32-battery-monitoring-esphome.html
+  - platform: adc
+    id: battery_voltage
+    pin: GPIO35 # A13
+    name: ESP32 Battery Voltage
+    update_interval: 60s
+    attenuation: 11db
+    filters:
+      - lambda: return (x / 3.9) * 2 * 3.3 * 1.1;
+
+  - platform: adc
+    pin: GPIO34 # A2
+    id: moisture
+    update_interval: 60s
+    name: Moisture Sensor Voltage
+    accuracy_decimals: 3
+    unit_of_measurement: V
+    filters:
+      - sliding_window_moving_average:
+          window_size: 10
+          send_every: 5


### PR DESCRIPTION


---



- 758cf42 | Add ESPHome moisture sensor config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration for an ESP32 soil moisture sensor, allowing users to monitor soil moisture levels and battery voltage.
	- Enhanced usability with clear naming and structured parameters for easy setup and integration with the ESPHome platform.
	- Included essential networking settings for secure Wi-Fi connectivity and OTA updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->