### PR TITLE
Add MQTT Sensor for MtrxPi content queue

### DIFF
--- a/entities/mqtt/sensor/mtrxpi/content_queue.yaml
+++ b/entities/mqtt/sensor/mtrxpi/content_queue.yaml
@@ -1,0 +1,14 @@
+---
+force_update: true
+
+icon: mdi:plus-box-multiple
+
+name: MtrxPi | Content Queue
+
+state_topic: /mtrxpi/matrix/content-queue/state
+
+unique_id: mtrxpi_content_queue
+
+json_attributes_topic: /mtrxpi/matrix/content-queue/attributes
+
+unit_of_measurement: items

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -3320,7 +3320,7 @@ File: [`media_player/topaz_sr10.yaml`](entities/media_player/topaz_sr10.yaml)
 
 ## Mqtt
 
-<details><summary><h3>Entities (103)</h3></summary>
+<details><summary><h3>Entities (104)</h3></summary>
 
 <details><summary><strong>MtrxPi | Clock: Scale</strong></summary>
 
@@ -3901,6 +3901,17 @@ File: [`mqtt/sensor/mtrxpi/average_load_5_min.yaml`](entities/mqtt/sensor/mtrxpi
 - State Topic: /homeassistant/mtrxpi/stats
 
 File: [`mqtt/sensor/mtrxpi/boot_time.yaml`](entities/mqtt/sensor/mtrxpi/boot_time.yaml)
+</details>
+
+<details><summary><strong>MtrxPi | Content Queue</strong></summary>
+
+**Entity ID: `sensor.mtrxpi_content_queue`**
+
+- Icon: [`mdi:plus-box-multiple`](https://pictogrammers.com/library/mdi/icon/plus-box-multiple/)
+- State Topic: /mtrxpi/matrix/content-queue/state
+- Unit Of Measurement: `items`
+
+File: [`mqtt/sensor/mtrxpi/content_queue.yaml`](entities/mqtt/sensor/mtrxpi/content_queue.yaml)
 </details>
 
 <details><summary><strong>MtrxPi CPU Temperature</strong></summary>


### PR DESCRIPTION


---



- 80280ec | Add MQTT Sensor for MtrxPi content queue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a content queue configuration for the MtrxPi sensor within the MQTT framework, enabling efficient management of content items and state tracking.
	- Added capabilities for state publication, unique identification, JSON attribute transmission, and forced updates for enhanced integration and user experience.
	- Visual icon representation and standardized measurement units improve clarity and usability in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->