### PR TITLE
Add MtrxPi brightness control based on quiet hours

### DIFF
--- a/entities/automation/binary_sensor/quiet_hours/off.yaml
+++ b/entities/automation/binary_sensor/quiet_hours/off.yaml
@@ -1,0 +1,19 @@
+---
+alias: /binary-sensor/quiet-hours/off
+
+id: binary_sensor_quiet_hours_off
+
+mode: single
+
+trigger:
+  platform: state
+  entity_id: binary_sensor.quiet_hours
+  from: "on"
+  to: "off"
+
+action:
+  - service: number.set_value
+    target:
+      entity_id: number.mtrxpi_matrix_brightness
+    data:
+      value: 100

--- a/entities/automation/binary_sensor/quiet_hours/on.yaml
+++ b/entities/automation/binary_sensor/quiet_hours/on.yaml
@@ -62,3 +62,9 @@ action:
                 entity_id: "{{ entity_id }}"
               data:
                 datetime: "{{ new_dttm }}"
+
+  - service: number.set_value
+    target:
+      entity_id: number.mtrxpi_matrix_brightness
+    data:
+      value: 50

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (124)</h3></summary>
+<details><summary><h3>Entities (125)</h3></summary>
 
 <details><summary><code>/automation/auto-reload</code></summary>
 
@@ -74,6 +74,19 @@ File: [`automation/binary_sensor/hallway_motion_sensor/on.yaml`](entities/automa
 - Mode: `single`
 
 File: [`automation/binary_sensor/hallway_motion_sensor/timeout.yaml`](entities/automation/binary_sensor/hallway_motion_sensor/timeout.yaml)
+</details>
+
+<details><summary><code>/binary-sensor/quiet-hours/off</code></summary>
+
+**Entity ID: `automation.binary_sensor_quiet_hours_off`**
+
+> *No description provided*
+
+- Alias: /binary-sensor/quiet-hours/off
+- ID: `binary_sensor_quiet_hours_off`
+- Mode: `single`
+
+File: [`automation/binary_sensor/quiet_hours/off.yaml`](entities/automation/binary_sensor/quiet_hours/off.yaml)
 </details>
 
 <details><summary><code>/binary-sensor/quiet-hours/on</code></summary>


### PR DESCRIPTION


---



- 5f50bbb | Add MtrxPi brightness control based on quiet hours


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automation for adjusting brightness based on quiet hours settings, enhancing user control over home environment.
	- Added functionality to set brightness to specific values when quiet hours are activated or deactivated.

- **Bug Fixes**
	- Improved stability by ensuring that brightness adjustments are not executed concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->