### PR TITLE
Add automation to turn desk lamp on in dark office

### DIFF
--- a/entities/automation/light/desk_lamp/turn_on.yaml
+++ b/entities/automation/light/desk_lamp/turn_on.yaml
@@ -1,0 +1,31 @@
+---
+alias: /light/desk-lamp/turn-on
+
+id: light_desk_lamp_turn_on
+
+description: >-
+  Turn the desk lamp on when someone enters the room, all of the lights are off,
+  and the blinds are down
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: binary_sensor.will_s_desk_occupancy
+    to: "on"
+
+condition:
+  - condition: state
+    entity_id: light.office_lights
+    state: "off"
+
+  - condition: state
+    entity_id: cover.office_blinds
+    state: closed
+
+action:
+  - service: light.turn_on
+    target:
+      entity_id: light.desk_lamp
+    data:
+      brightness: "{{ states('sensor.lighting_modifier') | int(50) }}"

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (114)</h3></summary>
+<details><summary><h3>Entities (115)</h3></summary>
 
 <details><summary><code>/automation/auto-reload</code></summary>
 
@@ -851,6 +851,19 @@ File: [`automation/input_select/target_git_branch/option_selected.yaml`](entitie
 - Mode: `restart`
 
 File: [`automation/input_select/target_git_branch/set_options.yaml`](entities/automation/input_select/target_git_branch/set_options.yaml)
+</details>
+
+<details><summary><code>/light/desk-lamp/turn-on</code></summary>
+
+**Entity ID: `automation.light_desk_lamp_turn_on`**
+
+> Turn the desk lamp on when someone enters the room, all of the lights are off, and the blinds are down
+
+- Alias: /light/desk-lamp/turn-on
+- ID: `light_desk_lamp_turn_on`
+- Mode: `single`
+
+File: [`automation/light/desk_lamp/turn_on.yaml`](entities/automation/light/desk_lamp/turn_on.yaml)
 </details>
 
 <details><summary><code>/light/kitchen-spotlights/on-off</code></summary>


### PR DESCRIPTION


---



- 7238a6d | Add automation to turn desk lamp on in dark office


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automation rule for the desk lamp that turns it on when occupancy is detected, provided that the office lights are off and the blinds are closed. 
	- The desk lamp's brightness is adjusted based on a lighting sensor, defaulting to 50 if no sensor value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->