### PR TITLE
Keep the diffuser's light in sync with the diffuser state

### DIFF
--- a/entities/automation/switch/lounge_diffuser/state_change.yaml
+++ b/entities/automation/switch/lounge_diffuser/state_change.yaml
@@ -1,0 +1,20 @@
+---
+alias: /switch/lounge-diffuser/state-change
+
+id: switch_lounge_diffuser_state_change
+
+description: Keep the diffuser's light in sync with the diffuser state
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: switch.lounge_diffuser
+    to:
+      - "on"
+      - "off"
+
+action:
+  - service: switch.turn_{{ trigger.to_state.state }}
+    target:
+      entity_id: switch.lounge_diffuser_light

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (127)</h3></summary>
+<details><summary><h3>Entities (128)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -1733,6 +1733,19 @@ File: [`automation/switch/dry_box_dehumidifier/timeout.yaml`](entities/automatio
 - Mode: `single`
 
 File: [`automation/switch/dry_box_dehumidifier/turn_on.yaml`](entities/automation/switch/dry_box_dehumidifier/turn_on.yaml)
+</details>
+
+<details><summary><code>/switch/lounge-diffuser/state-change</code></summary>
+
+**Entity ID: `automation.switch_lounge_diffuser_state_change`**
+
+> Keep the diffuser's light in sync with the diffuser state
+
+- Alias: /switch/lounge-diffuser/state-change
+- ID: `switch_lounge_diffuser_state_change`
+- Mode: `single`
+
+File: [`automation/switch/lounge_diffuser/state_change.yaml`](entities/automation/switch/lounge_diffuser/state_change.yaml)
 </details>
 
 <details><summary><code>/switch/mtrxpi-power/off</code></summary>


### PR DESCRIPTION


---



- f615ffe | Keep the diffuser's light in sync with the diffuser state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automation for the lounge diffuser's light, synchronizing its state with the diffuser.
	- New configuration allows the light to turn on or off based on the diffuser's state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->