### PR TITLE
Add template sensor for Air Purifier fan speed

### DIFF
--- a/entities/template/sensor/air_purifier_fan_speed.yaml
+++ b/entities/template/sensor/air_purifier_fan_speed.yaml
@@ -1,0 +1,36 @@
+---
+name: Air Purifier Fan Speed
+
+unique_id: air_purifier_fan_speed
+
+state: >-
+  {% if not states("fan.air_purifier") | bool(false) %}
+    0
+  {% elif state_attr('fan.air_purifier', 'mode') == 'auto' %}
+    {{ states("sensor.air_purifier_air_quality") | int(0) }}
+  {% elif state_attr('fan.air_purifier', 'mode') == 'manual' %}
+    {{ state_attr('fan.air_purifier', 'percentage') | int(0) / 25 }}
+  {% elif state_attr('fan.air_purifier', 'mode') == 'off' %}
+    0
+  {% endif %}
+
+state_class: measurement
+
+icon: >-
+  {% if not states("fan.air_purifier") | bool(false) %}
+    mdi:fan-off
+  {% elif state_attr('fan.air_purifier', 'mode') == 'auto' %}
+    mdi:fan-auto
+  {% elif state_attr('fan.air_purifier', 'mode') == 'manual' %}
+    {% if state_attr('fan.air_purifier', 'percentage') == 25 %}
+      mdi:fan-speed-1
+    {% elif state_attr('fan.air_purifier', 'percentage') == 50 %}
+      mdi:fan-speed-2
+    {% elif state_attr('fan.air_purifier', 'percentage') == 75 %}
+      mdi:fan-speed-3
+    {% else %}
+      mdi:fan
+    {% endif %}
+  {% else %}
+    mdi:fan
+  {% endif %}

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -6611,7 +6611,7 @@ File: [`switch/prusa_i3_mk3_power.yaml`](entities/switch/prusa_i3_mk3_power.yaml
 
 ## Template
 
-<details><summary><h3>Entities (108)</h3></summary>
+<details><summary><h3>Entities (109)</h3></summary>
 
 <details><summary><strong>Bank Holiday</strong></summary>
 
@@ -7296,6 +7296,34 @@ File: [`template/sensor/addon_stats/zigbee2mqtt_memory_usage.yaml`](entities/tem
 - Icon: [`mdi:map-marker`](https://pictogrammers.com/library/mdi/icon/map-marker/)
 
 File: [`template/sensor/address_line_1.yaml`](entities/template/sensor/address_line_1.yaml)
+</details>
+
+<details><summary><strong>Air Purifier Fan Speed</strong></summary>
+
+**Entity ID: `sensor.air_purifier_fan_speed`**
+
+- Icon:
+
+```jinja
+{% if not states("fan.air_purifier") | bool(false) %}
+  mdi:fan-off
+{% elif state_attr('fan.air_purifier', 'mode') == 'auto' %}
+  mdi:fan-auto
+{% elif state_attr('fan.air_purifier', 'mode') == 'manual' %}
+  {% if state_attr('fan.air_purifier', 'percentage') == 25 %}
+    mdi:fan-speed-1
+  {% elif state_attr('fan.air_purifier', 'percentage') == 50 %}
+    mdi:fan-speed-2
+  {% elif state_attr('fan.air_purifier', 'percentage') == 75 %}
+    mdi:fan-speed-3
+  {% else %}
+    mdi:fan
+  {% endif %}
+{% else %}
+  mdi:fan
+{% endif %}
+```
+File: [`template/sensor/air_purifier_fan_speed.yaml`](entities/template/sensor/air_purifier_fan_speed.yaml)
 </details>
 
 <details><summary><strong>Current Hour</strong></summary>


### PR DESCRIPTION


---



- 8057901 | Add template sensor for Air Purifier fan speed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new sensor configuration for Air Purifier Fan Speed
  - Implemented dynamic state tracking based on fan modes
  - Created intelligent icon display that changes with fan status
  - Supports automatic, manual, and off fan states
  - Provides measurement-class sensor for air purifier fan speed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->