### PR TITLE
Reduce Purifier delay

### DIFF
--- a/entities/automation/fan/air_purifier/control.yaml
+++ b/entities/automation/fan/air_purifier/control.yaml
@@ -48,7 +48,7 @@ action:
         conditions: "{{ not tv_is_on and trigger.id == 'lounge_diffuser_state' }}"
         sequence:
           - delay:
-              minutes: 30
+              minutes: 15
 
           - condition: "{{ not ( states('remote.lounge_tv') | bool(false) ) }}"
 


### PR DESCRIPTION


---



- afe3579 | Reduce Purifier delay


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Reduced air purifier activation delay from 30 to 15 minutes after diffuser is turned off, improving system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->