### PR TITLE
Add air purifier quiet mode and update fan speed control

### DIFF
--- a/entities/automation/fan/air_purifier/control.yaml
+++ b/entities/automation/fan/air_purifier/control.yaml
@@ -1,21 +1,13 @@
 ---
 alias: /fan/air-purifier/control
-description: >
-  Controls the air purifier based on TV and diffuser states. Turns off when diffuser
-  is on, operates in limited auto mode when TV is on (25-50% based on PM2.5), and
-  returns to auto mode when both are off after a 30-minute delay.
+
 id: fan_air_purifier_control
 
 mode: single
 
-trigger:
-  - platform: state
-    entity_id: remote.lounge_tv
-    id: lounge_tv_state
-    not_to:
-      - "unavailable"
-      - "unknown"
+max_exceeded: silent
 
+trigger:
   - platform: state
     entity_id: sensor.air_purifier_pm2_5
     id: air_purifier_pm2_5
@@ -31,9 +23,8 @@ trigger:
       - "unknown"
 
 variables:
-  tv_is_on: "{{ states('remote.lounge_tv') | bool(false) }}"
-  pm2_5: "{{ states('sensor.air_purifier_pm2_5') | float(50) }}"
   diffuser_is_on: "{{ states('switch.lounge_diffuser') | bool(false) }}"
+  purifier_is_on: "{{ states('fan.air_purifier') | bool(false) }}"
 
 action:
   - choose:
@@ -45,41 +36,17 @@ action:
               entity_id: fan.air_purifier
 
       - alias: Diffuser turned off; delay & turn on air purifier
-        conditions: "{{ not tv_is_on and trigger.id == 'lounge_diffuser_state' }}"
+        conditions: "{{ trigger.id == 'lounge_diffuser_state' }}"
         sequence:
           - delay:
               minutes: 15
 
-          - condition: "{{ not ( states('remote.lounge_tv') | bool(false) ) }}"
-
-          - service: fan.set_preset_mode
-            data:
-              preset_mode: auto
+          - service: script.turn_on
             target:
-              entity_id: fan.air_purifier
+              entity_id: script.air_purifier_update_fan_speed
 
-      # Diffuser is off, TV is on, air purifier is in auto mode; set air purifier to
-      # appropriate percentage (i.e. limited auto)
-      - alias: '"Limited Auto"'
-        conditions: >-
-          {{
-            tv_is_on and
-            state_attr('fan.air_purifier', 'preset_mode') == 'auto' and
-            trigger.id == 'air_purifier_pm2_5'
-          }}
+      - conditions: "{{ trigger.id == 'air_purifier_pm2_5' and purifier_is_on }}"
         sequence:
-          - service: fan.set_percentage
+          - service: script.turn_on
             target:
-              entity_id: fan.air_purifier
-            data:
-              percentage: "{{ iif(pm2_5 > 12, 50, 25) }}"
-
-      # TV turned off and diffuser is off; set air purifier to auto mode
-      - alias: TV Turned Off
-        conditions: "{{ not tv_is_on and trigger.id == 'lounge_tv_state' }}"
-        sequence:
-          - service: fan.set_preset_mode
-            data:
-              preset_mode: auto
-            target:
-              entity_id: fan.air_purifier
+              entity_id: script.air_purifier_update_fan_speed

--- a/entities/automation/input_boolean/air_purifier_quiet_mode/state_change.yaml
+++ b/entities/automation/input_boolean/air_purifier_quiet_mode/state_change.yaml
@@ -1,0 +1,18 @@
+---
+alias: /input-boolean/air-purifier-quiet-mode/state-change
+
+id: input_boolean_air_purifier_quiet_mode_state_change
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: input_boolean.air_purifier_quiet_mode
+
+# Only run if it's on
+condition: "{{ states('fan.air_purifier') | bool(false) }}"
+
+action:
+  - service: script.turn_on
+    target:
+      entity_id: script.air_purifier_update_fan_speed

--- a/entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml
+++ b/entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml
@@ -1,0 +1,44 @@
+---
+alias: /input-boolean/air-purifier-quiet-mode/toggle
+
+id: input_boolean_air_purifier_quiet_mode_toggle
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: remote.lounge_tv
+    id: lounge_tv_state
+    to:
+      - "on"
+      - "off"
+
+  - trigger: calendar
+    id: vic_work_start
+    event: start
+    entity_id: calendar.vic_work
+
+  - trigger: calendar
+    id: vic_work_end
+    event: end
+    entity_id: calendar.vic_work
+
+variables:
+  tv_is_on: "{{ states('remote.lounge_tv') | bool(false) }}"
+  vic_at_home: "{{ states('person.vic') == 'home' }}"
+  vic_in_meeting: "{{ states('calendar.vic_work') | bool(false) }}"
+
+# Skip the automation for vic_work triggers when Vic isn't home
+condition: "{{ not trigger.id.startswith('vic_work_') or states('person.vic') == 'home' }}"
+
+action:
+  - if: "{{ tv_is_on or (vic_in_meeting and vic_at_home) }}"
+    then:
+      - service: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.air_purifier_quiet_mode
+
+  - else:
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.air_purifier_quiet_mode

--- a/entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml
+++ b/entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml
@@ -38,7 +38,7 @@ action:
         target:
           entity_id: input_boolean.air_purifier_quiet_mode
 
-  - else:
+    else:
       - service: input_boolean.turn_off
         target:
           entity_id: input_boolean.air_purifier_quiet_mode

--- a/entities/input_boolean/air_purifier/air_purifier_quiet_mode.yaml
+++ b/entities/input_boolean/air_purifier/air_purifier_quiet_mode.yaml
@@ -1,0 +1,4 @@
+---
+name: Air Purifier | Quiet Mode
+
+icon: mdi:air-purifier

--- a/entities/script/fan/air_purifier/air_purifier_update_fan_speed.yaml
+++ b/entities/script/fan/air_purifier/air_purifier_update_fan_speed.yaml
@@ -1,0 +1,33 @@
+---
+alias: "Air Purifier: Update Fan Speed"
+
+description: Update the air purifier fan speed based on the current air quality and other conditions
+
+mode: single
+
+max_exceeded: silent
+
+variables:
+  pm2_5: "{{ states('sensor.air_purifier_pm2_5') | float(0) }}"
+
+  quiet_mode: "{{ states('input_boolean.air_purifier_quiet_mode') | bool(false) }}"
+
+sequence:
+  - service: fan.set_percentage
+    target:
+      entity_id: fan.air_purifier
+    data:
+      percentage: >-
+        {% if quiet_mode %}
+          {{ iif(pm2_5 > 12, 50, 25) }}
+        {% else %}
+          {% if pm2_5 > 55 %}
+            100
+          {% elif pm2_5 > 35 %}
+            75
+          {% elif pm2_5 > 12 %}
+            50
+          {% else %}
+            25
+          {% endif %}
+        {% endif %}

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (129)</h3></summary>
+<details><summary><h3>Entities (131)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -490,7 +490,7 @@ File: [`automation/event/repair/state_change.yaml`](entities/automation/event/re
 
 **Entity ID: `automation.fan_air_purifier_control`**
 
-> Controls the air purifier based on TV and diffuser states. Turns off when diffuser is on, operates in limited auto mode when TV is on (25-50% based on PM2.5), and returns to auto mode when both are off after a 30-minute delay.
+> *No description provided*
 
 - Alias: /fan/air-purifier/control
 - ID: `fan_air_purifier_control`
@@ -499,9 +499,8 @@ File: [`automation/event/repair/state_change.yaml`](entities/automation/event/re
 
 ```json
 {
-  "tv_is_on": "{{ states('remote.lounge_tv') | bool(false) }}",
-  "pm2_5": "{{ states('sensor.air_purifier_pm2_5') | float(50) }}",
-  "diffuser_is_on": "{{ states('switch.lounge_diffuser') | bool(false) }}"
+  "diffuser_is_on": "{{ states('switch.lounge_diffuser') | bool(false) }}",
+  "purifier_is_on": "{{ states('fan.air_purifier') | bool(false) }}"
 }
 ```
 File: [`automation/fan/air_purifier/control.yaml`](entities/automation/fan/air_purifier/control.yaml)
@@ -801,6 +800,40 @@ File: [`automation/hue_remote/lounge/button_4/long_press.yaml`](entities/automat
 - Mode: `single`
 
 File: [`automation/hue_remote/lounge/button_4/press.yaml`](entities/automation/hue_remote/lounge/button_4/press.yaml)
+</details>
+
+<details><summary><code>/input-boolean/air-purifier-quiet-mode/state-change</code></summary>
+
+**Entity ID: `automation.input_boolean_air_purifier_quiet_mode_state_change`**
+
+> *No description provided*
+
+- Alias: /input-boolean/air-purifier-quiet-mode/state-change
+- ID: `input_boolean_air_purifier_quiet_mode_state_change`
+- Mode: `single`
+
+File: [`automation/input_boolean/air_purifier_quiet_mode/state_change.yaml`](entities/automation/input_boolean/air_purifier_quiet_mode/state_change.yaml)
+</details>
+
+<details><summary><code>/input-boolean/air-purifier-quiet-mode/toggle</code></summary>
+
+**Entity ID: `automation.input_boolean_air_purifier_quiet_mode_toggle`**
+
+> *No description provided*
+
+- Alias: /input-boolean/air-purifier-quiet-mode/toggle
+- ID: `input_boolean_air_purifier_quiet_mode_toggle`
+- Mode: `single`
+- Variables:
+
+```json
+{
+  "tv_is_on": "{{ states('remote.lounge_tv') | bool(false) }}",
+  "vic_at_home": "{{ states('person.vic') == 'home' }}",
+  "vic_in_meeting": "{{ states('calendar.vic_work') | bool(false) }}"
+}
+```
+File: [`automation/input_boolean/air_purifier_quiet_mode/toggle.yaml`](entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml)
 </details>
 
 <details><summary><code>/input-datetime/cosmo/next-clean-due/set</code></summary>
@@ -2461,7 +2494,16 @@ File: [`device_tracker/google_maps/primary_gmail_address.yaml`](entities/device_
 
 ## Input Boolean
 
-<details><summary><h3>Entities (28)</h3></summary>
+<details><summary><h3>Entities (29)</h3></summary>
+
+<details><summary><strong>Air Purifier | Quiet Mode</strong></summary>
+
+**Entity ID: `input_boolean.air_purifier_quiet_mode`**
+
+- Icon: [`mdi:air-purifier`](https://pictogrammers.com/library/mdi/icon/air-purifier/)
+
+File: [`input_boolean/air_purifier/air_purifier_quiet_mode.yaml`](entities/input_boolean/air_purifier/air_purifier_quiet_mode.yaml)
+</details>
 
 <details><summary><strong>AD: Monzo Auto-Save</strong></summary>
 
@@ -5294,7 +5336,7 @@ File: [`rest/tomorrow_io_realtime_weather.yaml`](entities/rest/tomorrow_io_realt
 
 ## Script
 
-<details><summary><h3>Entities (28)</h3></summary>
+<details><summary><h3>Entities (29)</h3></summary>
 
 <details><summary><strong>AD: Monzo Auto Save</strong></summary>
 
@@ -5545,6 +5587,24 @@ File: [`script/cosmo/cosmo_tag_scanned.yaml`](entities/script/cosmo/cosmo_tag_sc
 - Mode: `parallel`
 
 File: [`script/debug_persistent_notification.yaml`](entities/script/debug_persistent_notification.yaml)
+</details>
+
+<details><summary><strong>Air Purifier: Update Fan Speed</strong></summary>
+
+**Entity ID: `script.air_purifier_update_fan_speed`**
+
+> Update the air purifier fan speed based on the current air quality and other conditions
+
+- Mode: `single`
+- Variables:
+
+```json
+{
+  "pm2_5": "{{ states('sensor.air_purifier_pm2_5') | float(0) }}",
+  "quiet_mode": "{{ states('input_boolean.air_purifier_quiet_mode') | bool(false) }}"
+}
+```
+File: [`script/fan/air_purifier/air_purifier_update_fan_speed.yaml`](entities/script/fan/air_purifier/air_purifier_update_fan_speed.yaml)
 </details>
 
 <details><summary><strong>Log Exception</strong></summary>


### PR DESCRIPTION


---



- a7d6c06 | Add air purifier quiet mode and update fan speed control
- 6e93733 | typo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new input boolean for air purifier quiet mode
	- Introduced dynamic air purifier control based on air quality and user presence
	- Created a script to automatically adjust air purifier fan speed

- **Improvements**
	- Streamlined air purifier control logic
	- Enhanced air quality management with conditional fan speed settings
	- Added intelligent mode switching based on TV and meeting states

- **Bug Fixes**
	- Removed unnecessary dependencies in air purifier automation
	- Simplified control mechanisms for more efficient operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->