### PR TITLE
Turn air freshener on for high AQI values

### DIFF
--- a/entities/automation/switch/air_freshener/turn_on.yaml
+++ b/entities/automation/switch/air_freshener/turn_on.yaml
@@ -11,7 +11,7 @@ description: >-
 mode: single
 
 trigger:
-  - platform: state
+  - platform: numeric_state
     entity_id: sensor.air_purifier_pm2_5
     above: 25
     for:

--- a/entities/automation/switch/air_freshener/turn_on.yaml
+++ b/entities/automation/switch/air_freshener/turn_on.yaml
@@ -1,0 +1,28 @@
+---
+alias: /switch/air-freshener/turn-on
+
+id: switch_air_freshener_turn_on
+
+description: >-
+  Turn the air freshener on when the AQI is high and the Air Purifier is on: if the purifier is off
+  then it's because something that smells nice (e.g. diffuser, incense) is on, so the freshener isn't
+  needed; if it's on, then assume the AQI is high because of e.g. cooking, so the freshener is needed
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: sensor.air_purifier_pm2_5
+    above: 25
+    for:
+      minutes: 1
+
+condition:
+  - condition: state
+    entity_id: fan.air_purifier
+    state: "on"
+
+action:
+  - service: switch.turn_on
+    target:
+      entity_id: switch.air_freshener

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (135)</h3></summary>
+<details><summary><h3>Entities (136)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -1787,6 +1787,19 @@ File: [`automation/remote/will_s_desk/button_2/single.yaml`](entities/automation
 - Mode: `single`
 
 File: [`automation/switch/air_freshener/timeout.yaml`](entities/automation/switch/air_freshener/timeout.yaml)
+</details>
+
+<details><summary><code>/switch/air-freshener/turn-on</code></summary>
+
+**Entity ID: `automation.switch_air_freshener_turn_on`**
+
+> Turn the air freshener on when the AQI is high and the Air Purifier is on: if the purifier is off then it's because something that smells nice (e.g. diffuser, incense) is on, so the freshener isn't needed; if it's on, then assume the AQI is high because of e.g. cooking, so the freshener is needed
+
+- Alias: /switch/air-freshener/turn-on
+- ID: `switch_air_freshener_turn_on`
+- Mode: `single`
+
+File: [`automation/switch/air_freshener/turn_on.yaml`](entities/automation/switch/air_freshener/turn_on.yaml)
 </details>
 
 <details><summary><code>/switch/charging-hub/turn-off</code></summary>


### PR DESCRIPTION


---



- e907b14 | Turn air freshener on for high AQI values
- e8cb5ac | Fix invalid trigger def


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new automation that activates your air freshener when air quality declines.  
  - The system ensures the air purifier is active and monitors air quality metrics before triggering the air freshener.  
  - Operates in a single-run mode, preventing overlapping activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->