### PR TITLE
Ensure diffuser light mode is set before changing color

### DIFF
--- a/entities/automation/diffuser/lounge/set_color.yaml
+++ b/entities/automation/diffuser/lounge/set_color.yaml
@@ -21,16 +21,22 @@ trigger:
     not_to: Solid
 
 action:
-  - service: select.select_option
-    target:
-      entity_id: select.lounge_diffuser_light_mode
-    data:
-      option: Solid
+  - if: "{{ not is_state('select.lounge_diffuser_light_mode', 'Solid') }}"
 
-  - wait_template: "{{ is_state('select.lounge_diffuser_light_mode', 'Solid') }}"
-    timeout:
-      seconds: 10
-    continue_on_timeout: true
+    then:
+      - service: select.select_option
+        target:
+          entity_id: select.lounge_diffuser_light_mode
+        data:
+          option: Solid
+
+      - delay:
+          seconds: 1
+
+      - wait_template: "{{ is_state('select.lounge_diffuser_light_mode', 'Solid') }}"
+        timeout:
+          seconds: 10
+        continue_on_timeout: true
 
   - service: select.select_option
     target:


### PR DESCRIPTION


---



- a7243f5 | Ensure diffuser light mode is set before changing color


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Eliminates unnecessary waiting when the diffuser is already in Solid mode, reducing delays before color changes.
  - Adds a brief stabilization delay to improve reliability when switching to Solid mode.
  - Ensures the system only waits for Solid mode when needed, maintaining the existing timeout behavior.
  - Preserves correct execution of Tangerine color selection after mode verification, improving overall responsiveness and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->