### PR TITLE
Nanoleaf bedroom sunrise

### DIFF
--- a/.cursor/rules/home-assistant-automation-syntax.mdc
+++ b/.cursor/rules/home-assistant-automation-syntax.mdc
@@ -15,7 +15,7 @@ description: Home Assistant automation trigger syntax rules
 - platform: time
   at: input_datetime.next_bedroom_sunrise  # Direct entity reference
 
-# Numeric state triggers  
+# Numeric state triggers
 - platform: numeric_state
   entity_id: sensor.temperature
   above: input_number.max_temp  # Direct entity reference
@@ -61,7 +61,7 @@ description: Home Assistant automation trigger syntax rules
 - platform: time
   at: input_datetime.my_datetime  # Entity reference
 
-# Incorrect  
+# Incorrect
 - platform: time
   at: "{{ states('input_datetime.my_datetime') }}"  # Unnecessary template
 ```

--- a/.cursor/rules/home-assistant-automation-syntax.mdc
+++ b/.cursor/rules/home-assistant-automation-syntax.mdc
@@ -1,0 +1,110 @@
+---
+alwaysApply: true
+description: Home Assistant automation trigger syntax rules
+---
+
+# Home Assistant Automation Trigger Syntax
+
+## General Rule: Use Direct Entity References
+
+**ALWAYS use direct entity references in triggers, NOT `states()` functions**
+
+### Correct Syntax Examples
+```yaml
+# Time triggers
+- platform: time
+  at: input_datetime.next_bedroom_sunrise  # Direct entity reference
+
+# Numeric state triggers  
+- platform: numeric_state
+  entity_id: sensor.temperature
+  above: input_number.max_temp  # Direct entity reference
+  below: input_number.min_temp  # Direct entity reference
+
+# State triggers
+- platform: state
+  entity_id: binary_sensor.motion
+  to: "on"
+
+# Zone triggers
+- platform: zone
+  entity_id: person.will
+  zone: zone.home
+```
+
+### Incorrect Syntax Examples
+```yaml
+# DON'T use states() function in triggers
+- platform: time
+  at: "{{ states('input_datetime.next_bedroom_sunrise') }}"  # WRONG
+
+- platform: numeric_state
+  entity_id: sensor.temperature
+  above: "{{ states('input_number.max_temp') }}"  # WRONG
+  below: "{{ states('input_number.min_temp') }}"   # WRONG
+```
+
+## Key Rules
+
+1. **All trigger types**: Use direct entity references, not `states()` function
+2. **Template triggers**: Use `{{ }}` syntax only when needed for complex expressions
+3. **Entity references**: Most trigger fields accept direct entity IDs without quotes
+4. **String values**: Only use quotes when the value is a literal string
+
+## Common Patterns
+
+### Time-based triggers
+```yaml
+# Correct
+- platform: time
+  at: "07:30:00"  # Fixed time
+- platform: time
+  at: input_datetime.my_datetime  # Entity reference
+
+# Incorrect  
+- platform: time
+  at: "{{ states('input_datetime.my_datetime') }}"  # Unnecessary template
+```
+
+### Numeric state triggers
+```yaml
+# Correct
+- platform: numeric_state
+  entity_id: sensor.temperature
+  above: input_number.max_temp
+  below: input_number.min_temp
+
+# Incorrect
+- platform: numeric_state
+  entity_id: sensor.temperature
+  above: "{{ states('input_number.max_temp') }}"
+  below: "{{ states('input_number.min_temp') }}"
+```
+
+### State triggers
+```yaml
+# Correct
+- platform: state
+  entity_id: binary_sensor.motion
+  to: "on"
+
+# Template when needed
+- platform: template
+  value_template: "{{ is_state('binary_sensor.motion', 'on') and is_state('light.living_room', 'off') }}"
+```
+
+### Event triggers
+```yaml
+# Correct
+- platform: event
+  event_type: mobile_app_notification_action
+  event_data:
+    action: BEDROOM_SUNRISE_DELAY_15
+```
+
+## Best Practices
+
+1. Use direct entity references when possible
+2. Only use templates when you need complex logic
+3. Keep trigger conditions simple and readable
+4. Use descriptive automation aliases that match file paths

--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -11,6 +11,9 @@ trigger:
   - platform: time
     at: input_datetime.next_bedroom_sunrise
 
+variables:
+  original_start_time: "{{ trigger.at }}"
+
 action:
   - alias: Turn on bedroom shapes with deep orange
     service: light.turn_on
@@ -26,11 +29,12 @@ action:
 
   - alias: Gradual brightness increase over 30 minutes
     repeat:
-      count: 30
+      while: >-
+        {{
+          is_state('input_datetime.next_bedroom_sunrise', original_start_time) and
+          repeat.index < 30
+        }}
       sequence:
-        - alias: Wait 1 minute
-          delay:
-            minutes: 1
         - alias: Increase brightness
           service: light.turn_on
           target:
@@ -39,6 +43,10 @@ action:
             brightness_pct: "{{ (repeat.index * 3.33) | round(0) }}"
             rgb_color: [255, 140, 0] # Deep orange
             transition: 60 # 1 minute transition
+
+        - alias: Wait 1 minute
+          delay:
+            minutes: 1
 
   - alias: Final brightness at 100%
     service: light.turn_on

--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -12,7 +12,7 @@ trigger:
     at: input_datetime.next_bedroom_sunrise
 
 variables:
-  original_start_time: "{{ trigger.at }}"
+  original_start_time: "{{ states('input_datetime.next_bedroom_sunrise') }}"
 
 action:
   - alias: Turn on bedroom shapes with deep orange

--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -1,0 +1,66 @@
+---
+alias: /input-datetime/next-bedroom-sunrise/sunrise-start
+
+id: input_datetime_next_bedroom_sunrise_sunrise_start
+
+description: Start the bedroom sunrise alarm when the scheduled time is reached
+
+mode: single
+
+trigger:
+  - platform: time
+    at: input_datetime.next_bedroom_sunrise
+
+action:
+  - alias: Turn on bedroom shapes with deep orange
+    service: light.turn_on
+    target:
+      entity_id: light.bedroom_shapes
+    data:
+      brightness_pct: 1
+      rgb_color: [255, 140, 0] # Deep orange
+      transition: 0
+
+  - alias: Send sunrise notification
+    service: script.send_bedroom_sunrise_notification
+
+  - alias: Gradual brightness increase over 30 minutes
+    repeat:
+      count: 30
+      sequence:
+        - alias: Wait 1 minute
+          delay:
+            minutes: 1
+        - alias: Increase brightness
+          service: light.turn_on
+          target:
+            entity_id: light.bedroom_shapes
+          data:
+            brightness_pct: "{{ (repeat.index * 3.33) | round(0) }}"
+            rgb_color: [255, 140, 0] # Deep orange
+            transition: 60 # 1 minute transition
+
+  - alias: Final brightness at 100%
+    service: light.turn_on
+    target:
+      entity_id: light.bedroom_shapes
+    data:
+      brightness_pct: 100
+      rgb_color: [255, 140, 0] # Deep orange
+      transition: 60
+
+  - alias: Reset next sunrise to tomorrow
+    service: script.reset_next_bedroom_sunrise
+
+  - alias: Clear sunrise notifications
+    service: notify.mobile_app_victorias_iphone
+    data:
+      message: clear_notification
+      data:
+        tag: sunrise-alarm
+
+  - service: notify.mobile_app_will_s_pixel_6_pro
+    data:
+      message: clear_notification
+      data:
+        tag: sunrise-alarm

--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -5,7 +5,7 @@ id: input_datetime_next_bedroom_sunrise_sunrise_start
 
 description: Start the bedroom sunrise alarm when the scheduled time is reached
 
-mode: single
+mode: restart
 
 trigger:
   - platform: time

--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -63,14 +63,6 @@ action:
         service: script.reset_next_bedroom_sunrise
 
   - alias: Clear sunrise notifications
-    service: notify.mobile_app_victorias_iphone
+    service: script.send_bedroom_sunrise_notification
     data:
-      message: clear_notification
-      data:
-        tag: sunrise-alarm
-
-  - service: notify.mobile_app_will_s_pixel_6_pro
-    data:
-      message: clear_notification
-      data:
-        tag: sunrise-alarm
+      clear_notification: true

--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -48,17 +48,19 @@ action:
           delay:
             minutes: 1
 
-  - alias: Final brightness at 100%
-    service: light.turn_on
-    target:
-      entity_id: light.bedroom_shapes
-    data:
-      brightness_pct: 100
-      rgb_color: [255, 140, 0] # Deep orange
-      transition: 60
+  - if: "{{ is_state('input_datetime.next_bedroom_sunrise', original_start_time) }}"
+    then:
+      - alias: Final brightness at 100%
+        service: light.turn_on
+        target:
+          entity_id: light.bedroom_shapes
+        data:
+          brightness_pct: 100
+          rgb_color: [255, 140, 0] # Deep orange
+          transition: 60
 
-  - alias: Reset next sunrise to tomorrow
-    service: script.reset_next_bedroom_sunrise
+      - alias: Reset next sunrise to tomorrow
+        service: script.reset_next_bedroom_sunrise
 
   - alias: Clear sunrise notifications
     service: notify.mobile_app_victorias_iphone

--- a/entities/automation/light/bedroom_shapes/bon_appetit.yaml
+++ b/entities/automation/light/bedroom_shapes/bon_appetit.yaml
@@ -1,0 +1,43 @@
+---
+alias: /light/bedroom-shapes/bon-appetit
+
+id: light_bedroom_shapes_bon_appetit
+
+description: Reset bedroom shapes to "bon appetit" effect at 10 AM
+
+mode: single
+
+trigger:
+  - platform: time
+    at: "10:00:00"
+
+action:
+  - if:
+      - condition: state
+        entity_id: light.bedroom_shapes
+        state: "off"
+    then:
+      - alias: Set bedroom shapes to bon appetit effect at 1%
+        service: light.turn_on
+        target:
+          entity_id: light.bedroom_shapes
+        data:
+          effect: "bon appetit"
+          brightness_pct: 1
+
+      - alias: Wait for effect to play
+        delay:
+          seconds: 5
+
+      - alias: Turn off after effect
+        service: light.turn_off
+        target:
+          entity_id: light.bedroom_shapes
+
+    else:
+      - alias: Set bedroom shapes to bon appetit effect (preserve brightness)
+        service: light.turn_on
+        target:
+          entity_id: light.bedroom_shapes
+        data:
+          effect: "bon appetit"

--- a/entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml
+++ b/entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml
@@ -16,6 +16,11 @@ trigger:
   - platform: event
     event_type: mobile_app_notification_action
     event_data:
+      action: BEDROOM_SUNRISE_DELAY_30
+    id: BEDROOM_SUNRISE_DELAY_30
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
       action: BEDROOM_SUNRISE_DELAY_60
     id: BEDROOM_SUNRISE_DELAY_60
 
@@ -23,6 +28,8 @@ variables:
   delay_minutes: >-
     {% if trigger.id == 'BEDROOM_SUNRISE_DELAY_15' %}
       15
+    {% elif trigger.id == 'BEDROOM_SUNRISE_DELAY_30' %}
+      30
     {% elif trigger.id == 'BEDROOM_SUNRISE_DELAY_60' %}
       60
     {% endif %}

--- a/entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml
+++ b/entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml
@@ -42,5 +42,7 @@ action:
     data:
       transition: 5
 
-  - alias: Send updated sunrise notification
+  - alias: Clear sunrise notifications
     service: script.send_bedroom_sunrise_notification
+    data:
+      clear_notification: true

--- a/entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml
+++ b/entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml
@@ -1,0 +1,46 @@
+---
+alias: /mobile-app/notification-action/bedroom-sunrise-delay
+
+id: mobile_app_notification_action_bedroom_sunrise_delay
+
+description: Handle delay for sunrise alarm (15 or 60 minutes)
+
+mode: single
+
+trigger:
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: BEDROOM_SUNRISE_DELAY_15
+    id: BEDROOM_SUNRISE_DELAY_15
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: BEDROOM_SUNRISE_DELAY_60
+    id: BEDROOM_SUNRISE_DELAY_60
+
+variables:
+  delay_minutes: >-
+    {% if trigger.id == 'BEDROOM_SUNRISE_DELAY_15' %}
+      15
+    {% elif trigger.id == 'BEDROOM_SUNRISE_DELAY_60' %}
+      60
+    {% endif %}
+
+action:
+  - alias: Set sunrise to X minutes from now
+    service: input_datetime.set_datetime
+    target:
+      entity_id: input_datetime.next_bedroom_sunrise
+    data:
+      datetime: "{{ (now() + timedelta(minutes=delay_minutes)).strftime('%Y-%m-%d %H:%M:%S') }}"
+
+  - alias: Dim light slowly
+    service: light.turn_off
+    target:
+      entity_id: light.bedroom_shapes
+    data:
+      transition: 5
+
+  - alias: Send updated sunrise notification
+    service: script.send_bedroom_sunrise_notification

--- a/entities/automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml
+++ b/entities/automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml
@@ -22,17 +22,9 @@ action:
       transition: 5
 
   - alias: Clear sunrise notifications
-    service: notify.mobile_app_victorias_iphone
+    service: script.send_bedroom_sunrise_notification
     data:
-      message: clear_notification
-      data:
-        tag: sunrise-alarm
-
-  - service: notify.mobile_app_will_s_pixel_6_pro
-    data:
-      message: clear_notification
-      data:
-        tag: sunrise-alarm
+      clear_notification: true
 
   - alias: Reset next sunrise to tomorrow
     service: script.reset_next_bedroom_sunrise

--- a/entities/automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml
+++ b/entities/automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml
@@ -1,0 +1,38 @@
+---
+alias: /mobile-app/notification-action/bedroom-sunrise-stop
+
+id: mobile_app_notification_action_bedroom_sunrise_stop
+
+description: Stop the sunrise alarm completely
+
+mode: single
+
+trigger:
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: BEDROOM_SUNRISE_STOP
+
+action:
+  - alias: Turn off bedroom shapes
+    service: light.turn_off
+    target:
+      entity_id: light.bedroom_shapes
+    data:
+      transition: 5
+
+  - alias: Clear sunrise notifications
+    service: notify.mobile_app_victorias_iphone
+    data:
+      message: clear_notification
+      data:
+        tag: sunrise-alarm
+
+  - service: notify.mobile_app_will_s_pixel_6_pro
+    data:
+      message: clear_notification
+      data:
+        tag: sunrise-alarm
+
+  - alias: Reset next sunrise to tomorrow
+    service: script.reset_next_bedroom_sunrise

--- a/entities/input_datetime/next_bedroom_sunrise.yaml
+++ b/entities/input_datetime/next_bedroom_sunrise.yaml
@@ -1,0 +1,8 @@
+---
+name: Next Bedroom Sunrise
+
+has_date: true
+
+has_time: true
+
+icon: mdi:weather-sunset-up

--- a/entities/script/reset_next_bedroom_sunrise.yaml
+++ b/entities/script/reset_next_bedroom_sunrise.yaml
@@ -1,0 +1,20 @@
+---
+alias: Reset Next Bedroom Sunrise
+
+description: >-
+  Set the next bedroom sunrise to tomorrow at the appropriate time (7:30 AM weekdays, 8:30 AM
+  weekends)
+
+mode: single
+
+sequence:
+  - alias: Set next sunrise to tomorrow at 7:30 AM (weekday) or 8:30 AM (weekend)
+    service: input_datetime.set_datetime
+    target:
+      entity_id: input_datetime.next_bedroom_sunrise
+    data:
+      datetime: >-
+        {% set tomorrow = (now() + timedelta(days=1)).date() %}
+        {% set is_weekend = tomorrow.weekday() >= 5 %}
+        {% set time_str = "08:30:00" if is_weekend else "07:30:00" %}
+        {{ tomorrow.strftime('%Y-%m-%d') }} {{ time_str }}

--- a/entities/script/send_bedroom_sunrise_notification.yaml
+++ b/entities/script/send_bedroom_sunrise_notification.yaml
@@ -36,7 +36,7 @@ sequence:
       - alias: Calculate notification timeout
         variables:
           notif_timeout: >-
-            {{ states('input_datetime.next_bedroom_sunrise') | as_timestamp - now().timestamp() }}
+            {{ states('input_datetime.next_bedroom_sunrise') | as_timestamp + (30 * 60) }}
 
       - alias: Send sunrise notification to Vic
         if:
@@ -62,7 +62,7 @@ sequence:
                   sound: none
                   interruption-level: passive
                   badge: 1
-                subtitle: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"
+                subtitle: "Sun up in {{ (notif_timeout / 60) | round(0) }} minutes"
 
       - alias: Send sunrise notification to Will
         if:
@@ -96,4 +96,4 @@ sequence:
                 notification_icon: "mdi:weather-sunset-up"
                 sticky: true
                 alert_once: true
-                subject: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"
+                subject: "Sun up in {{ (notif_timeout / 60) | round(0) }} minutes"

--- a/entities/script/send_bedroom_sunrise_notification.yaml
+++ b/entities/script/send_bedroom_sunrise_notification.yaml
@@ -35,8 +35,7 @@ sequence:
     else:
       - alias: Calculate notification timeout
         variables:
-          notif_timeout: >-
-            {{ states('input_datetime.next_bedroom_sunrise') | as_timestamp + (30 * 60) }}
+          notif_timeout: 1800
 
       - alias: Send sunrise notification to Vic
         if:

--- a/entities/script/send_bedroom_sunrise_notification.yaml
+++ b/entities/script/send_bedroom_sunrise_notification.yaml
@@ -1,0 +1,71 @@
+---
+alias: Send Bedroom Sunrise Notification
+
+description: Send sunrise notification with countdown timer to both phones
+
+mode: single
+
+sequence:
+  - alias: Calculate notification timeout
+    variables:
+      notif_timeout: "{{ states('input_datetime.next_bedroom_sunrise') | as_timestamp - now().timestamp() }}"
+
+  - alias: Send sunrise notification to Vic
+    if:
+      - condition: state
+        entity_id: person.vic
+        state: home
+    then:
+      - service: notify.mobile_app_victorias_iphone
+        data:
+          title: Good morning!
+          message: Rise and shine!
+          data:
+            actions:
+              - action: BEDROOM_SUNRISE_DELAY_15
+                title: "Delay 15 mins"
+              - action: BEDROOM_SUNRISE_DELAY_60
+                title: "Delay 60 mins"
+              - action: BEDROOM_SUNRISE_STOP
+                title: "Stop Sunrise"
+            tag: sunrise-alarm
+            group: sunrise-alarm
+            push:
+              sound: none
+              interruption-level: passive
+              badge: 1
+            subtitle: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"
+
+  - alias: Send sunrise notification to Will
+    if:
+      - condition: state
+        entity_id: person.will
+        state: home
+    then:
+      - service: notify.mobile_app_will_s_pixel_6_pro
+        data:
+          title: Good morning!
+          message: Rise and shine!
+          data:
+            persistent: true
+            actions:
+              - action: BEDROOM_SUNRISE_DELAY_15
+                title: "Delay 15 mins"
+              - action: BEDROOM_SUNRISE_DELAY_60
+                title: "Delay 60 mins"
+              - action: BEDROOM_SUNRISE_STOP
+                title: "Stop Sunrise"
+            tag: sunrise-alarm
+            group: sunrise-alarm
+            channel: Sunrise
+            importance: min
+            vibrationPattern: "100"
+            timeout: "{{ notif_timeout }}"
+            chronometer: true
+            when: "{{ notif_timeout }}"
+            when_relative: true
+            sound: none
+            notification_icon: "mdi:weather-sunset-up"
+            sticky: true
+            alert_once: true
+            subject: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"

--- a/entities/script/send_bedroom_sunrise_notification.yaml
+++ b/entities/script/send_bedroom_sunrise_notification.yaml
@@ -50,9 +50,11 @@ sequence:
               data:
                 actions:
                   - action: BEDROOM_SUNRISE_DELAY_15
-                    title: "Delay 15 mins"
+                    title: "Start in 15 mins"
+                  - action: BEDROOM_SUNRISE_DELAY_30
+                    title: "Start in 30 mins"
                   - action: BEDROOM_SUNRISE_DELAY_60
-                    title: "Delay 60 mins"
+                    title: "Start in 60 mins"
                   - action: BEDROOM_SUNRISE_STOP
                     title: "Stop Sunrise"
                 tag: sunrise-alarm
@@ -61,7 +63,6 @@ sequence:
                   sound: none
                   interruption-level: passive
                   badge: 1
-                subtitle: "Sun up in {{ (notif_timeout / 60) | round(0) }} minutes"
 
       - alias: Send sunrise notification to Will
         if:
@@ -77,9 +78,11 @@ sequence:
                 persistent: true
                 actions:
                   - action: BEDROOM_SUNRISE_DELAY_15
-                    title: "Delay 15 mins"
+                    title: "Start in 15 mins"
+                  - action: BEDROOM_SUNRISE_DELAY_30
+                    title: "Start in 30 mins"
                   - action: BEDROOM_SUNRISE_DELAY_60
-                    title: "Delay 60 mins"
+                    title: "Start in 60 mins"
                   - action: BEDROOM_SUNRISE_STOP
                     title: "Stop Sunrise"
                 tag: sunrise-alarm
@@ -95,4 +98,3 @@ sequence:
                 notification_icon: "mdi:weather-sunset-up"
                 sticky: true
                 alert_once: true
-                subject: "Sun up in {{ (notif_timeout / 60) | round(0) }} minutes"

--- a/entities/script/send_bedroom_sunrise_notification.yaml
+++ b/entities/script/send_bedroom_sunrise_notification.yaml
@@ -8,7 +8,8 @@ mode: single
 sequence:
   - alias: Calculate notification timeout
     variables:
-      notif_timeout: "{{ states('input_datetime.next_bedroom_sunrise') | as_timestamp - now().timestamp() }}"
+      notif_timeout: >-
+        {{ states('input_datetime.next_bedroom_sunrise') | as_timestamp - now().timestamp() }}
 
   - alias: Send sunrise notification to Vic
     if:

--- a/entities/script/send_bedroom_sunrise_notification.yaml
+++ b/entities/script/send_bedroom_sunrise_notification.yaml
@@ -5,68 +5,95 @@ description: Send sunrise notification with countdown timer to both phones
 
 mode: single
 
+fields:
+  clear_notification:
+    description: Clear the notification
+    example: "true"
+    selector:
+      boolean:
+
+variables:
+  clear_notification: "{{ clear_notification | default(False) | bool(False) }}"
+
 sequence:
-  - alias: Calculate notification timeout
-    variables:
-      notif_timeout: >-
-        {{ states('input_datetime.next_bedroom_sunrise') | as_timestamp - now().timestamp() }}
+  - if: "{{ clear_notification }}"
 
-  - alias: Send sunrise notification to Vic
-    if:
-      - condition: state
-        entity_id: person.vic
-        state: home
     then:
-      - service: notify.mobile_app_victorias_iphone
+      - alias: Clear sunrise notifications
+        service: notify.mobile_app_victorias_iphone
         data:
-          title: Good morning!
-          message: Rise and shine!
+          message: clear_notification
           data:
-            actions:
-              - action: BEDROOM_SUNRISE_DELAY_15
-                title: "Delay 15 mins"
-              - action: BEDROOM_SUNRISE_DELAY_60
-                title: "Delay 60 mins"
-              - action: BEDROOM_SUNRISE_STOP
-                title: "Stop Sunrise"
             tag: sunrise-alarm
-            group: sunrise-alarm
-            push:
-              sound: none
-              interruption-level: passive
-              badge: 1
-            subtitle: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"
 
-  - alias: Send sunrise notification to Will
-    if:
-      - condition: state
-        entity_id: person.will
-        state: home
-    then:
       - service: notify.mobile_app_will_s_pixel_6_pro
         data:
-          title: Good morning!
-          message: Rise and shine!
+          message: clear_notification
           data:
-            persistent: true
-            actions:
-              - action: BEDROOM_SUNRISE_DELAY_15
-                title: "Delay 15 mins"
-              - action: BEDROOM_SUNRISE_DELAY_60
-                title: "Delay 60 mins"
-              - action: BEDROOM_SUNRISE_STOP
-                title: "Stop Sunrise"
             tag: sunrise-alarm
-            group: sunrise-alarm
-            channel: Sunrise
-            importance: min
-            vibrationPattern: "100"
-            timeout: "{{ notif_timeout }}"
-            chronometer: true
-            when: "{{ notif_timeout }}"
-            when_relative: true
-            sound: none
-            notification_icon: "mdi:weather-sunset-up"
-            sticky: true
-            alert_once: true
-            subject: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"
+
+    else:
+      - alias: Calculate notification timeout
+        variables:
+          notif_timeout: >-
+            {{ states('input_datetime.next_bedroom_sunrise') | as_timestamp - now().timestamp() }}
+
+      - alias: Send sunrise notification to Vic
+        if:
+          - condition: state
+            entity_id: person.vic
+            state: home
+        then:
+          - service: notify.mobile_app_victorias_iphone
+            data:
+              title: Good morning!
+              message: Rise and shine!
+              data:
+                actions:
+                  - action: BEDROOM_SUNRISE_DELAY_15
+                    title: "Delay 15 mins"
+                  - action: BEDROOM_SUNRISE_DELAY_60
+                    title: "Delay 60 mins"
+                  - action: BEDROOM_SUNRISE_STOP
+                    title: "Stop Sunrise"
+                tag: sunrise-alarm
+                group: sunrise-alarm
+                push:
+                  sound: none
+                  interruption-level: passive
+                  badge: 1
+                subtitle: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"
+
+      - alias: Send sunrise notification to Will
+        if:
+          - condition: state
+            entity_id: person.will
+            state: home
+        then:
+          - service: notify.mobile_app_will_s_pixel_6_pro
+            data:
+              title: Good morning!
+              message: Rise and shine!
+              data:
+                persistent: true
+                actions:
+                  - action: BEDROOM_SUNRISE_DELAY_15
+                    title: "Delay 15 mins"
+                  - action: BEDROOM_SUNRISE_DELAY_60
+                    title: "Delay 60 mins"
+                  - action: BEDROOM_SUNRISE_STOP
+                    title: "Stop Sunrise"
+                tag: sunrise-alarm
+                group: sunrise-alarm
+                channel: Sunrise
+                importance: min
+                vibrationPattern: "100"
+                timeout: "{{ notif_timeout }}"
+                chronometer: true
+                when: "{{ notif_timeout }}"
+                when_relative: true
+                sound: none
+                notification_icon: "mdi:weather-sunset-up"
+                sticky: true
+                alert_once: true
+                subject: "Sunrise in {{ (notif_timeout / 60) | round(0) }} minutes"

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (141)</h3></summary>
+<details><summary><h3>Entities (142)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -867,6 +867,19 @@ File: [`automation/input_select/target_git_branch/set_options.yaml`](entities/au
 File: [`automation/label/critical_battery/low_battery_alert.yaml`](entities/automation/label/critical_battery/low_battery_alert.yaml)
 </details>
 
+<details><summary><code>/light/bedroom-shapes/bon-appetit</code></summary>
+
+**Entity ID: `automation.light_bedroom_shapes_bon_appetit`**
+
+> Reset bedroom shapes to "bon appetit" effect at 10 AM
+
+- Alias: /light/bedroom-shapes/bon-appetit
+- ID: `light_bedroom_shapes_bon_appetit`
+- Mode: `single`
+
+File: [`automation/light/bedroom_shapes/bon_appetit.yaml`](entities/automation/light/bedroom_shapes/bon_appetit.yaml)
+</details>
+
 <details><summary><code>/light/desk-lamp/state-change</code></summary>
 
 **Entity ID: `automation.light_desk_lamp_state_change`**
@@ -1119,7 +1132,7 @@ File: [`automation/media_player/topaz_sr10/timeout.yaml`](entities/automation/me
 
 ```json
 {
-  "delay_minutes": "{% if trigger.id == 'BEDROOM_SUNRISE_DELAY_15' %}\n  15\n{% elif trigger.id == 'BEDROOM_SUNRISE_DELAY_60' %}\n  60\n{% endif %}"
+  "delay_minutes": "{% if trigger.id == 'BEDROOM_SUNRISE_DELAY_15' %}\n  15\n{% elif trigger.id == 'BEDROOM_SUNRISE_DELAY_30' %}\n  30\n{% elif trigger.id == 'BEDROOM_SUNRISE_DELAY_60' %}\n  60\n{% endif %}"
 }
 ```
 File: [`automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml`](entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (138)</h3></summary>
+<details><summary><h3>Entities (141)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -796,6 +796,19 @@ File: [`automation/input_boolean/air_purifier_quiet_mode/toggle.yaml`](entities/
 File: [`automation/input_datetime/home_assistant_start_time/set_datetime.yaml`](entities/automation/input_datetime/home_assistant_start_time/set_datetime.yaml)
 </details>
 
+<details><summary><code>/input-datetime/next-bedroom-sunrise/sunrise-start</code></summary>
+
+**Entity ID: `automation.input_datetime_next_bedroom_sunrise_sunrise_start`**
+
+> Start the bedroom sunrise alarm when the scheduled time is reached
+
+- Alias: /input-datetime/next-bedroom-sunrise/sunrise-start
+- ID: `input_datetime_next_bedroom_sunrise_sunrise_start`
+- Mode: `single`
+
+File: [`automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml`](entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml)
+</details>
+
 <details><summary><code>/input-select/gh-cli-active-user/option-selected</code></summary>
 
 **Entity ID: `automation.input_select_gh_cli_active_user_option_selected`**
@@ -1085,6 +1098,38 @@ File: [`automation/media_player/topaz_sr10/on.yaml`](entities/automation/media_p
 - Mode: `single`
 
 File: [`automation/media_player/topaz_sr10/timeout.yaml`](entities/automation/media_player/topaz_sr10/timeout.yaml)
+</details>
+
+<details><summary><code>/mobile-app/notification-action/bedroom-sunrise-delay</code></summary>
+
+**Entity ID: `automation.mobile_app_notification_action_bedroom_sunrise_delay`**
+
+> Handle delay for sunrise alarm (15 or 60 minutes)
+
+- Alias: /mobile-app/notification-action/bedroom-sunrise-delay
+- ID: `mobile_app_notification_action_bedroom_sunrise_delay`
+- Mode: `single`
+- Variables:
+
+```json
+{
+  "delay_minutes": "{% if trigger.id == 'BEDROOM_SUNRISE_DELAY_15' %}\n  15\n{% elif trigger.id == 'BEDROOM_SUNRISE_DELAY_60' %}\n  60\n{% endif %}"
+}
+```
+File: [`automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml`](entities/automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml)
+</details>
+
+<details><summary><code>/mobile-app/notification-action/bedroom-sunrise-stop</code></summary>
+
+**Entity ID: `automation.mobile_app_notification_action_bedroom_sunrise_stop`**
+
+> Stop the sunrise alarm completely
+
+- Alias: /mobile-app/notification-action/bedroom-sunrise-stop
+- ID: `mobile_app_notification_action_bedroom_sunrise_stop`
+- Mode: `single`
+
+File: [`automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml`](entities/automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml)
 </details>
 
 <details><summary><code>/mtrxpi/content-trigger/audio-visualiser</code></summary>
@@ -5064,7 +5109,7 @@ File: [`rest/tomorrow_io_realtime_weather.yaml`](entities/rest/tomorrow_io_realt
 
 ## Script
 
-<details><summary><h3>Entities (27)</h3></summary>
+<details><summary><h3>Entities (28)</h3></summary>
 
 <details><summary><strong>AD: Monzo Auto Save</strong></summary>
 
@@ -5818,6 +5863,17 @@ File: [`script/office_desk_standing_mode.yaml`](entities/script/office_desk_stan
 - Mode: `restart`
 
 File: [`script/office_desk_stop_moving.yaml`](entities/script/office_desk_stop_moving.yaml)
+</details>
+
+<details><summary><strong>Reset Next Bedroom Sunrise</strong></summary>
+
+**Entity ID: `script.reset_next_bedroom_sunrise`**
+
+> Set the next bedroom sunrise to tomorrow at the appropriate time (7:30 AM weekdays, 8:30 AM weekends)
+
+- Mode: `single`
+
+File: [`script/reset_next_bedroom_sunrise.yaml`](entities/script/reset_next_bedroom_sunrise.yaml)
 </details>
 
 <details><summary><strong>Send Bedroom Sunrise Notification</strong></summary>

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2661,7 +2661,7 @@ File: [`input_boolean/topaz_sr10/topaz_sr10_is_volume_muted.yaml`](entities/inpu
 
 ## Input Datetime
 
-<details><summary><h3>Entities (3)</h3></summary>
+<details><summary><h3>Entities (4)</h3></summary>
 
 <details><summary><strong>Home Assistant Start Time</strong></summary>
 
@@ -2683,6 +2683,17 @@ File: [`input_datetime/home_assistant_start_time.yaml`](entities/input_datetime/
 - Icon: [`mdi:bank-transfer`](https://pictogrammers.com/library/mdi/icon/bank-transfer/)
 
 File: [`input_datetime/last_auto_save.yaml`](entities/input_datetime/last_auto_save.yaml)
+</details>
+
+<details><summary><strong>Next Bedroom Sunrise</strong></summary>
+
+**Entity ID: `input_datetime.next_bedroom_sunrise`**
+
+- Has Date: `true`
+- Has Time: `true`
+- Icon: [`mdi:weather-sunset-up`](https://pictogrammers.com/library/mdi/icon/weather-sunset-up/)
+
+File: [`input_datetime/next_bedroom_sunrise.yaml`](entities/input_datetime/next_bedroom_sunrise.yaml)
 </details>
 
 <details><summary><strong>Rain Flash Cooldown</strong></summary>

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5064,7 +5064,7 @@ File: [`rest/tomorrow_io_realtime_weather.yaml`](entities/rest/tomorrow_io_realt
 
 ## Script
 
-<details><summary><h3>Entities (26)</h3></summary>
+<details><summary><h3>Entities (27)</h3></summary>
 
 <details><summary><strong>AD: Monzo Auto Save</strong></summary>
 
@@ -5818,6 +5818,17 @@ File: [`script/office_desk_standing_mode.yaml`](entities/script/office_desk_stan
 - Mode: `restart`
 
 File: [`script/office_desk_stop_moving.yaml`](entities/script/office_desk_stop_moving.yaml)
+</details>
+
+<details><summary><strong>Send Bedroom Sunrise Notification</strong></summary>
+
+**Entity ID: `script.send_bedroom_sunrise_notification`**
+
+> Send sunrise notification with countdown timer to both phones
+
+- Mode: `single`
+
+File: [`script/send_bedroom_sunrise_notification.yaml`](entities/script/send_bedroom_sunrise_notification.yaml)
 </details>
 
 <details><summary><strong>GH Issue Create</strong></summary>

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -805,7 +805,13 @@ File: [`automation/input_datetime/home_assistant_start_time/set_datetime.yaml`](
 - Alias: /input-datetime/next-bedroom-sunrise/sunrise-start
 - ID: `input_datetime_next_bedroom_sunrise_sunrise_start`
 - Mode: `single`
+- Variables:
 
+```json
+{
+  "original_start_time": "{{ trigger.at }}"
+}
+```
 File: [`automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml`](entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml)
 </details>
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -804,7 +804,7 @@ File: [`automation/input_datetime/home_assistant_start_time/set_datetime.yaml`](
 
 - Alias: /input-datetime/next-bedroom-sunrise/sunrise-start
 - ID: `input_datetime_next_bedroom_sunrise_sunrise_start`
-- Mode: `single`
+- Mode: `restart`
 - Variables:
 
 ```json

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5888,8 +5888,28 @@ File: [`script/reset_next_bedroom_sunrise.yaml`](entities/script/reset_next_bedr
 
 > Send sunrise notification with countdown timer to both phones
 
-- Mode: `single`
+- Fields:
 
+```json
+{
+  "clear_notification": {
+    "description": "Clear the notification",
+    "example": "true",
+    "selector": {
+      "boolean": null
+    }
+  }
+}
+```
+
+- Mode: `single`
+- Variables:
+
+```json
+{
+  "clear_notification": "{{ clear_notification | default(False) | bool(False) }}"
+}
+```
 File: [`script/send_bedroom_sunrise_notification.yaml`](entities/script/send_bedroom_sunrise_notification.yaml)
 </details>
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -809,7 +809,7 @@ File: [`automation/input_datetime/home_assistant_start_time/set_datetime.yaml`](
 
 ```json
 {
-  "original_start_time": "{{ trigger.at }}"
+  "original_start_time": "{{ states('input_datetime.next_bedroom_sunrise') }}"
 }
 ```
 File: [`automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml`](entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml)


### PR DESCRIPTION


---



- 0dd6cc5 | Add `input_datetime.next_bedroom_sunrise`
- fc77fdc | [pre-commit.ci] auto fixes from pre-commit.com hooks
- 5fea7cf | Add `script.send_bedroom_sunrise_notification`
- e3ee1a1 | [pre-commit.ci] auto fixes from pre-commit.com hooks
- d9ed36c | Bedroom Sunrise
- f472c44 | Refines sunrise simulation
- 5362b17 | Fix variable
- 441da7a | Add condition for final steps
- db6f63a | Refactors sunrise notification logic
- 543a44b | minor fixes
- f167549 | Fix timeout
- 48cf841 | Fixes and reset automation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Bedroom Sunrise routine: gentle 30‑minute sunrise lighting with notifications and automatic next-day scheduling.
  * Introduced mobile notification actions to delay (15/30/60 mins) or stop the sunrise.
  * Scheduled “Bon Appetit” light effect daily at 10:00 if bedroom light is off (brief on, then off).
* Improvements
  * New “Next Bedroom Sunrise” time setting and supporting scripts for scheduling and notifications.
* Documentation
  * Added guide on Home Assistant automation trigger syntax with examples and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->