### PR TITLE
Add auto-reload for SpeedTest integration

### DIFF
--- a/entities/automation/sensor/speedtest/unavailable.yaml
+++ b/entities/automation/sensor/speedtest/unavailable.yaml
@@ -1,0 +1,36 @@
+---
+alias: /sensor/speedtest/unavailable
+
+id: sensor_speedtest_unavailable
+
+description: >-
+  Reload speedtest config entry when any speedtest sensor becomes unavailable for 30 seconds
+
+mode: single
+
+max_exceeded: silent
+
+trigger:
+  - platform: state
+    entity_id:
+      - sensor.speedtest_upload
+      - sensor.speedtest_ping
+      - sensor.speedtest_download
+    to: "unavailable"
+    for:
+      seconds: 30
+
+action:
+  - service: script.debug_persistent_notification
+    data:
+      message: >-
+        Speedtest sensor {{ trigger.entity_id }} became unavailable for 30+ seconds.
+        Reloading speedtest config entry.
+      notification_title: Speedtest Sensor Unavailable
+      notification_id: speedtest_sensor_unavailable
+
+  - service: homeassistant.reload_config_entry
+    target:
+      entity_id: sensor.speedtest_download
+    data:
+      entry_id: 0cfae871c5302278e74c3ab42a713f09

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (142)</h3></summary>
+<details><summary><h3>Entities (143)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -1861,6 +1861,19 @@ File: [`automation/remote/will_s_desk/button_2/double.yaml`](entities/automation
 - Mode: `single`
 
 File: [`automation/remote/will_s_desk/button_2/single.yaml`](entities/automation/remote/will_s_desk/button_2/single.yaml)
+</details>
+
+<details><summary><code>/sensor/speedtest/unavailable</code></summary>
+
+**Entity ID: `automation.sensor_speedtest_unavailable`**
+
+> Reload speedtest config entry when any speedtest sensor becomes unavailable for 30 seconds
+
+- Alias: /sensor/speedtest/unavailable
+- ID: `sensor_speedtest_unavailable`
+- Mode: `single`
+
+File: [`automation/sensor/speedtest/unavailable.yaml`](entities/automation/sensor/speedtest/unavailable.yaml)
 </details>
 
 <details><summary><code>/sensor/storage-cc-ssd-transient-qbt-disk-used-percentage-notify-and-clear</code></summary>


### PR DESCRIPTION


---



- f261a0a | Add auto-reload for SpeedTest integration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automation that watches Speedtest sensors (download, upload, ping) and reacts if any stay unavailable for 30 seconds.
  * Sends a persistent notification to alert you when a sensor becomes unavailable.
  * Automatically reloads the related integration to restore sensor readings, reducing manual intervention and improving continuity of data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->