### PR TITLE
Only run sunrise sequence when someone home

### DIFF
--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -11,6 +11,8 @@ trigger:
   - platform: time
     at: input_datetime.next_bedroom_sunrise
 
+condition: "{{ states('zone.home') | int(0) > 0 }}"
+
 variables:
   original_start_time: "{{ states('input_datetime.next_bedroom_sunrise') }}"
 


### PR DESCRIPTION


---



- cb2f174 | Only run sunrise sequence when someone home


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sunrise routine now runs only when the home is occupied, preventing it from triggering while everyone is away.
  * Improves relevance of time-based actions by adding an occupancy check, reducing unwanted activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->