### PR TITLE
Auto-clear camera offline notification

### DIFF
--- a/entities/automation/camera/offline_notify_will.yaml
+++ b/entities/automation/camera/offline_notify_will.yaml
@@ -9,18 +9,22 @@ mode: queued
 
 max_exceeded: silent
 
-max: 2
+max: 4
 
 trigger:
   - platform: state
     entity_id: camera.basement
-    to: unavailable
+    to:
+      - recording
+      - unavailable
     for:
       minutes: 1
 
   - platform: state
     entity_id: camera.lounge
-    to: unavailable
+    to:
+      - recording
+      - unavailable
     for:
       minutes: 1
 
@@ -35,9 +39,20 @@ variables:
     {% endif %}
 
 action:
-  - service: script.notify_will
-    data:
-      title: "Camera Offline"
-      message: "{{ camera_name }} camera is offline (unavailable)."
-      group: camera-offline
-      mobile_notification_icon: mdi:cctv
+  - if: "{{ trigger.to_state.state == 'unavailable' }}"
+
+    then:
+      - service: script.notify_will
+        data:
+          title: "Camera Offline"
+          message: "{{ camera_name }} camera is offline"
+          group: camera-offline
+          mobile_notification_icon: mdi:cctv
+          notification_id: camera_offline_{{ camera_name }}
+
+    else:
+      - service: script.notify_will
+        data:
+          clear_notification: true
+          notification_id: camera_offline_{{ camera_name }}
+          message: clear_notification

--- a/entities/script/send_bedroom_sunrise_notification.yaml
+++ b/entities/script/send_bedroom_sunrise_notification.yaml
@@ -53,8 +53,6 @@ sequence:
                     title: "Start in 15 mins"
                   - action: BEDROOM_SUNRISE_DELAY_30
                     title: "Start in 30 mins"
-                  - action: BEDROOM_SUNRISE_DELAY_60
-                    title: "Start in 60 mins"
                   - action: BEDROOM_SUNRISE_STOP
                     title: "Stop Sunrise"
                 tag: sunrise-alarm
@@ -81,8 +79,6 @@ sequence:
                     title: "Start in 15 mins"
                   - action: BEDROOM_SUNRISE_DELAY_30
                     title: "Start in 30 mins"
-                  - action: BEDROOM_SUNRISE_DELAY_60
-                    title: "Start in 60 mins"
                   - action: BEDROOM_SUNRISE_STOP
                     title: "Stop Sunrise"
                 tag: sunrise-alarm


### PR DESCRIPTION


---



- 6f1f619 | Auto-clear camera offline notification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smarter camera offline notifications: alerts now trigger only when a camera is unavailable and automatically clear when it recovers or starts recording. Messaging is clearer and duplicate alerts are reduced with improved limits.
  * Sunrise notification update: streamlined options by removing the 60-minute delay. Users can now choose 15 or 30 minutes, or stop the reminder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->