### PR TITLE
Only reverse fan if needed

### DIFF
--- a/entities/automation/fan/will_s_office_fan/control.yaml
+++ b/entities/automation/fan/will_s_office_fan/control.yaml
@@ -73,13 +73,15 @@ action:
             target:
               entity_id: fan.will_s_office_fan
 
-          # Don't want to blow things around the room
-          # Has to be after the percentage is set
-          - service: fan.set_direction
-            data:
-              direction: reverse
-            target:
-              entity_id: fan.will_s_office_fan
+          - if: "{{ not is_state_attr('fan.will_s_office_fan', 'direction', 'reverse') }}"
+            then:
+              # Don't want to blow things around the room
+              # Has to be after the percentage is set
+              - service: fan.set_direction
+                data:
+                  direction: reverse
+                target:
+                  entity_id: fan.will_s_office_fan
 
       # Only 100% turn the fan off if the room is empty
       - alias: Good Air Quality (Empty Room)
@@ -122,10 +124,12 @@ action:
             target:
               entity_id: fan.will_s_office_fan
 
-          # Don't want to blow things around the room
-          # Has to be after the percentage is set
-          - service: fan.set_direction
-            data:
-              direction: reverse
-            target:
-              entity_id: fan.will_s_office_fan
+          - if: "{{ not is_state_attr('fan.will_s_office_fan', 'direction', 'reverse') }}"
+            then:
+              # Don't want to blow things around the room
+              # Has to be after the percentage is set
+              - service: fan.set_direction
+                data:
+                  direction: reverse
+                target:
+                  entity_id: fan.will_s_office_fan


### PR DESCRIPTION


---



- a7692b2 | Only reverse fan if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents redundant fan direction changes by only switching to reverse when needed, reducing unnecessary commands and potential wear.
  * Improves reliability during “Poor Air Quality” and “Room Exited with Poor Air Quality & Fan Off” scenarios by avoiding repeated reverse actions.

* **Refactor**
  * Introduced conditional guarding around fan direction changes to streamline behavior without altering existing HVAC speed/percentage logic or other automation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->