### PR TITLE
Fix heating action in bedroom schedule automation

### DIFF
--- a/entities/automation/schedule/bedroom_heating_schedule/on.yaml
+++ b/entities/automation/schedule/bedroom_heating_schedule/on.yaml
@@ -29,7 +29,9 @@ action:
     target:
       area_id: bedroom
 
-  - service: climate.turn_on
+  - action: climate.set_hvac_mode
+    data:
+      hvac_mode: heat
     target:
       entity_id:
         - climate.bedroom_radiator_1


### PR DESCRIPTION


---



- 3d8919a | Fix heating action in bedroom schedule automation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bedroom heating schedule now explicitly sets HVAC mode to Heat when activated, improving reliability and preventing devices from entering unexpected modes.
  * Applies to the bedroom radiators covered by the schedule; timing, triggers, and conditions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->