### PR TITLE
Stop heating Will's office if the window/door is opened

### DIFF
--- a/entities/automation/binary_sensor/will_s_office_opening_detected/on.yaml
+++ b/entities/automation/binary_sensor/will_s_office_opening_detected/on.yaml
@@ -1,7 +1,7 @@
 ---
-alias: /binary-sensor/office-opening-detected/on
+alias: /binary-sensor/will-s-office-opening-detected/on
 
-id: binary_sensor_office_opening_detected_on
+id: binary_sensor_will_s_office_opening_detected_on
 
 description: Turn off office heating when window or roof terrace door is opened for 5 seconds
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -148,27 +148,6 @@ File: [`automation/binary_sensor/lounge_occupancy/on.yaml`](entities/automation/
 File: [`automation/binary_sensor/lounge_occupancy/room_timeout.yaml`](entities/automation/binary_sensor/lounge_occupancy/room_timeout.yaml)
 </details>
 
-<details><summary><code>/binary-sensor/office-opening-detected/on</code></summary>
-
-**Entity ID: `automation.binary_sensor_office_opening_detected_on`**
-
-> Turn off office heating when window or roof terrace door is opened for 5 seconds
-
-- Alias: /binary-sensor/office-opening-detected/on
-- ID: `binary_sensor_office_opening_detected_on`
-- Mode: `restart`
-- Variables:
-
-```json
-{
-  "radiator_was_on": "{{ is_state('climate.will_s_office_radiator', 'heat') }}",
-  "fan_was_heating": "{{ is_state('climate.will_s_office_fan', 'heat') }}",
-  "notif_id": "office_heating_off"
-}
-```
-File: [`automation/binary_sensor/office_opening_detected/on.yaml`](entities/automation/binary_sensor/office_opening_detected/on.yaml)
-</details>
-
 <details><summary><code>/binary-sensor/quiet-hours/off</code></summary>
 
 **Entity ID: `automation.binary_sensor_quiet_hours_off`**
@@ -238,6 +217,27 @@ File: [`automation/binary_sensor/vic_s_office_occupancy/on.yaml`](entities/autom
 }
 ```
 File: [`automation/binary_sensor/vic_s_office_occupancy/state_change.yaml`](entities/automation/binary_sensor/vic_s_office_occupancy/state_change.yaml)
+</details>
+
+<details><summary><code>/binary-sensor/will-s-office-opening-detected/on</code></summary>
+
+**Entity ID: `automation.binary_sensor_will_s_office_opening_detected_on`**
+
+> Turn off office heating when window or roof terrace door is opened for 5 seconds
+
+- Alias: /binary-sensor/will-s-office-opening-detected/on
+- ID: `binary_sensor_will_s_office_opening_detected_on`
+- Mode: `restart`
+- Variables:
+
+```json
+{
+  "radiator_was_on": "{{ is_state('climate.will_s_office_radiator', 'heat') }}",
+  "fan_was_heating": "{{ is_state('climate.will_s_office_fan', 'heat') }}",
+  "notif_id": "office_heating_off"
+}
+```
+File: [`automation/binary_sensor/will_s_office_opening_detected/on.yaml`](entities/automation/binary_sensor/will_s_office_opening_detected/on.yaml)
 </details>
 
 <details><summary><code>/binary-sensor/will-s-office-presence-sensor/state-change</code></summary>


### PR DESCRIPTION


---



- eec7211 | Stop heating Will's office if the window/door is opened
- 54692f3 | Run actions in parallel
- 80881ea | Rename automation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces an automation that detects when the office window or door remains open for 5 seconds and, if active, turns off the radiator and/or fan.
  - Sends a persistent mobile notification titled “Office heating disabled” detailing which devices were turned off, grouped with office heating, and automatically clears after 10 minutes.
  - Executes shutdown actions in parallel and restarts promptly if triggered again during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->