### PR TITLE
Add control for turning fan off with heating on

### DIFF
--- a/entities/automation/schedule/bedroom_heating_schedule/on.yaml
+++ b/entities/automation/schedule/bedroom_heating_schedule/on.yaml
@@ -25,9 +25,11 @@ condition:
         below: 15
 
 action:
-  - action: fan.turn_off
-    target:
-      area_id: bedroom
+  - if: "{{ is_state('input_boolean.turn_off_bedroom_fan_for_scheduled_heating', 'on') }}"
+    then:
+      - action: fan.turn_off
+        target:
+          area_id: bedroom
 
   - action: climate.set_hvac_mode
     data:

--- a/entities/input_boolean/turn_off_bedroom_fan_for_scheduled_heating.yaml
+++ b/entities/input_boolean/turn_off_bedroom_fan_for_scheduled_heating.yaml
@@ -1,0 +1,4 @@
+---
+name: Turn Off Bedroom Fan for Scheduled Heating
+
+icon: mdi:fan-off

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2647,7 +2647,7 @@ File: [`device_tracker/luci/openwrt_vm.yaml`](entities/device_tracker/luci/openw
 
 ## Input Boolean
 
-<details><summary><h3>Entities (28)</h3></summary>
+<details><summary><h3>Entities (29)</h3></summary>
 
 <details><summary><strong>Air Purifier | Quiet Mode</strong></summary>
 
@@ -2899,6 +2899,15 @@ File: [`input_boolean/mini_crt_power.yaml`](entities/input_boolean/mini_crt_powe
 - Icon: [`mdi:volume-off`](https://pictogrammers.com/library/mdi/icon/volume-off/)
 
 File: [`input_boolean/topaz_sr10/topaz_sr10_is_volume_muted.yaml`](entities/input_boolean/topaz_sr10/topaz_sr10_is_volume_muted.yaml)
+</details>
+
+<details><summary><strong>Turn Off Bedroom Fan for Scheduled Heating</strong></summary>
+
+**Entity ID: `input_boolean.turn_off_bedroom_fan_for_scheduled_heating`**
+
+- Icon: [`mdi:fan-off`](https://pictogrammers.com/library/mdi/icon/fan-off/)
+
+File: [`input_boolean/turn_off_bedroom_fan_for_scheduled_heating.yaml`](entities/input_boolean/turn_off_bedroom_fan_for_scheduled_heating.yaml)
 </details>
 
 </details>


### PR DESCRIPTION


---



- 549afbc | Add control for turning fan off with heating on


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-configurable setting to control bedroom fan behavior during scheduled heating operations. The fan's turn-off action is now optional—users can enable or disable automatic fan turn-off based on personal comfort preferences. This provides flexible climate management, allowing residents to customize how their bedroom fan behaves during heating cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->