### PR TITLE
Enables turning off heating from notifications

### DIFF
--- a/entities/automation/mobile_app/notification_action/central_heating_turn_off.yaml
+++ b/entities/automation/mobile_app/notification_action/central_heating_turn_off.yaml
@@ -1,0 +1,20 @@
+---
+alias: /mobile-app/notification-action/central-heating-turn-off
+
+id: mobile_app_notification_action_central_heating_turn_off
+
+description: Turn off central heating from notification action
+
+mode: single
+
+trigger:
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: CENTRAL_HEATING_TURN_OFF
+
+action:
+  - alias: Turn off central heating
+    action: switch.turn_off
+    target:
+      entity_id: switch.central_heating

--- a/entities/automation/switch/central_heating/on.yaml
+++ b/entities/automation/switch/central_heating/on.yaml
@@ -27,3 +27,6 @@ action:
         when: "{{ now().timestamp() | int }}"
         when_relative: false
         sound: "none"
+        actions:
+          - action: "CENTRAL_HEATING_TURN_OFF"
+            title: "Turn Off"

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (156)</h3></summary>
+<details><summary><h3>Entities (157)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -1247,6 +1247,19 @@ File: [`automation/mobile_app/notification_action/bedroom_sunrise_delay.yaml`](e
 - Mode: `single`
 
 File: [`automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml`](entities/automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml)
+</details>
+
+<details><summary><code>/mobile-app/notification-action/central-heating-turn-off</code></summary>
+
+**Entity ID: `automation.mobile_app_notification_action_central_heating_turn_off`**
+
+> Turn off central heating from notification action
+
+- Alias: /mobile-app/notification-action/central-heating-turn-off
+- ID: `mobile_app_notification_action_central_heating_turn_off`
+- Mode: `single`
+
+File: [`automation/mobile_app/notification_action/central_heating_turn_off.yaml`](entities/automation/mobile_app/notification_action/central_heating_turn_off.yaml)
 </details>
 
 <details><summary><code>/mtrxpi/content-trigger/audio-visualiser</code></summary>


### PR DESCRIPTION


---



- 5e51d32 | Enables turning off heating from notifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Central heating can now be turned off directly from mobile app notifications
  * Added "Turn Off" button to central heating status notifications for convenient remote control
  * New notification-triggered automation enables quick shutdown of central heating system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->