### PR TITLE
Add check for Shapes already on to sunrise automation

### DIFF
--- a/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
+++ b/entities/automation/input_datetime/next_bedroom_sunrise/sunrise_start.yaml
@@ -19,6 +19,13 @@ variables:
   sunrise_duration: "{{ states('input_number.bedroom_sunrise_duration') | int(30) }}"
 
 action:
+  - if: "{{ is_state('light.bedroom_shapes', 'on') }}"
+    then:
+      - alias: Reset next sunrise to tomorrow
+        service: script.reset_next_bedroom_sunrise
+
+      - stop: "Bedroom shapes are already on, skipping sunrise start"
+
   - alias: Turn on bedroom shapes with deep orange
     service: light.turn_on
     target:


### PR DESCRIPTION


---



- 68d28c0 | Add check for Shapes already on to sunrise automation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sunrise automation to prevent redundant triggering when lights are already on. The automation now skips the sequence and reschedules for the following day instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->