### PR TITLE
Add time reqs to office fan automation triggers

### DIFF
--- a/entities/automation/fan/vic_s_office_fan/control.yaml
+++ b/entities/automation/fan/vic_s_office_fan/control.yaml
@@ -16,11 +16,15 @@ trigger:
     entity_id: sensor.vic_s_office_fan_pm_2_5
     above: input_number.vic_s_office_fan_pm2_5_threshold
     id: pm25_high
+    for:
+      minutes: 1
 
   - platform: numeric_state
     entity_id: sensor.vic_s_office_fan_pm_2_5
     below: input_number.vic_s_office_fan_pm2_5_threshold
     id: pm25_low
+    for:
+      minutes: 1
 
   - platform: numeric_state
     entity_id: sensor.vic_s_office_fan_volatile_organic_compounds_index
@@ -41,7 +45,7 @@ trigger:
     from: "on"
     id: room_exited
     for:
-      minutes: 1
+      minutes: 5
 
 variables:
   pm25_high: >

--- a/entities/automation/fan/will_s_office_fan/control.yaml
+++ b/entities/automation/fan/will_s_office_fan/control.yaml
@@ -16,11 +16,15 @@ trigger:
     entity_id: sensor.will_s_office_fan_pm_2_5
     above: input_number.will_s_office_fan_pm2_5_threshold
     id: pm25_high
+    for:
+      minutes: 1
 
   - platform: numeric_state
     entity_id: sensor.will_s_office_fan_pm_2_5
     below: input_number.will_s_office_fan_pm2_5_threshold
     id: pm25_low
+    for:
+      minutes: 1
 
   - platform: numeric_state
     entity_id: sensor.will_s_office_fan_volatile_organic_compounds_index
@@ -41,7 +45,7 @@ trigger:
     from: "on"
     id: room_exited
     for:
-      minutes: 1
+      minutes: 5
 
 variables:
   pm25_high: >


### PR DESCRIPTION


---



- 3e6a6ac | Add time reqs to office fan automation triggers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced fan automation stability by adding 1-minute confirmation delay to air quality sensor triggers across office installations, reducing false activations.
  * Extended inactivity detection timeout from 1 to 5 minutes for improved response to occupancy changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->