### PR TITLE
Allow office door to be open when grow light turns on

### DIFF
--- a/entities/automation/light/will_s_office_grow_light/on.yaml
+++ b/entities/automation/light/will_s_office_grow_light/on.yaml
@@ -16,7 +16,6 @@ trigger:
         is_state('binary_sensor.will_s_office_occupancy', 'off') and
         is_state('binary_sensor.roof_terrace_door_contact', 'off') and
         is_state('binary_sensor.will_s_office_window_contact', 'off') and
-        is_state('binary_sensor.will_s_office_door_contact', 'off') and
         is_state('binary_sensor.bedroom_door_contact', 'off') and
         (states('sensor.sun_elevation') | float(-10) < -3) and
         (


### PR DESCRIPTION


---



- 41a4d24 | Allow office door to be open when office light turns on


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified grow light automation to operate with improved trigger conditions. The automation now activates without a specific constraint that was previously required, allowing more flexible scheduling during the designated time window. Grow light behavior and brightness settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->