### PR TITLE
Fix noisy countable reminders

### DIFF
--- a/dev_tools/generate_habit_files.py
+++ b/dev_tools/generate_habit_files.py
@@ -598,7 +598,11 @@ trigger:
   - platform: time
     at: input_datetime.XXXUSERXXX_habit_countable_XXXNUMXXX_reminder_time
 
-condition: "{{{{ states('input_number.XXXUSERXXX_habit_countable_XXXNUMXXX') | int(0) == 0 }}}}"
+condition: >-
+  {{
+    states('input_number.XXXUSERXXX_habit_countable_XXXNUMXXX') | int(0) == 0 and
+    states("input_text.XXXUSERXXX_habit_countable_XXXNUMXXX_name") not in ["", "unknown"]
+  }}
 
 variables:
   habit_name: >-

--- a/entities/automation/input_datetime/habit/will_habit_countable_1/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_countable_1/reminder.yaml
@@ -11,7 +11,11 @@ trigger:
   - platform: time
     at: input_datetime.will_habit_countable_1_reminder_time
 
-condition: "{{ states('input_number.will_habit_countable_1') | int(0) == 0 }}"
+condition: >-
+  {{
+    states('input_number.will_habit_countable_1') | int(0) == 0 and
+    states("input_text.will_habit_countable_1_name") not in ["", "unknown"]
+  }}
 
 variables:
   habit_name: >-

--- a/entities/automation/input_datetime/habit/will_habit_countable_2/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_countable_2/reminder.yaml
@@ -11,7 +11,11 @@ trigger:
   - platform: time
     at: input_datetime.will_habit_countable_2_reminder_time
 
-condition: "{{ states('input_number.will_habit_countable_2') | int(0) == 0 }}"
+condition: >-
+  {{
+    states('input_number.will_habit_countable_2') | int(0) == 0 and
+    states("input_text.will_habit_countable_2_name") not in ["", "unknown"]
+  }}
 
 variables:
   habit_name: >-


### PR DESCRIPTION


---



- 2dab3c7 | Fix noisy countable reminders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Habit reminders are now prevented from triggering when the habit name is missing, empty, or not properly configured. This ensures reminders only activate for habits with valid names set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->