### PR TITLE
Turn garden light on when door opens

### DIFF
--- a/entities/automation/binary_sensor/garden_door/open.yaml
+++ b/entities/automation/binary_sensor/garden_door/open.yaml
@@ -1,0 +1,24 @@
+---
+alias: /binary-sensor/garden-door/open
+
+id: binary_sensor_garden_door_open
+
+mode: single
+
+max_exceeded: silent
+
+trigger:
+  - platform: state
+    entity_id: binary_sensor.garden_door
+    from: "off"
+    to: "on"
+
+condition: "{{ states('sensor.sun_elevation') | float(10) <= 3 }}"
+
+action:
+  - service: light.turn_on
+    target:
+      entity_id: light.garden_light
+    data:
+      brightness_pct: 100
+      transition: 1

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (229)</h3></summary>
+<details><summary><h3>Entities (230)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -67,6 +67,19 @@ File: [`automation/binary_sensor/dining_area_occupancy/state_change.yaml`](entit
 - Mode: `single`
 
 File: [`automation/binary_sensor/front_door/open.yaml`](entities/automation/binary_sensor/front_door/open.yaml)
+</details>
+
+<details><summary><code>/binary-sensor/garden-door/open</code></summary>
+
+**Entity ID: `automation.binary_sensor_garden_door_open`**
+
+> *No description provided*
+
+- Alias: /binary-sensor/garden-door/open
+- ID: `binary_sensor_garden_door_open`
+- Mode: `single`
+
+File: [`automation/binary_sensor/garden_door/open.yaml`](entities/automation/binary_sensor/garden_door/open.yaml)
 </details>
 
 <details><summary><code>/binary-sensor/kitchen-hallway-occupancy/on</code></summary>


### PR DESCRIPTION


---



- c37b342 | Turn garden light on when door opens


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Garden door automation created: Activates the garden light at full brightness with a 1-second fade-in when the garden door opens and sun elevation is at or below 3 degrees.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->