### PR TITLE
Config for TV-aware lighting

### DIFF
--- a/entities/automation/binary_sensor/lounge_occupancy/on.yaml
+++ b/entities/automation/binary_sensor/lounge_occupancy/on.yaml
@@ -29,11 +29,11 @@ action:
         then:
           - if: >
               {{
-                is_state('remote.lounge_tv', 'on') or
-                is_state('remote.lounge_chromecast', 'on') or
-                is_state('media_player.lounge_chromecast', 'on') or
-                is_state('media_player.lounge_tv_2', 'on') or
-                is_state('media_player.lounge_chromecast_remote', 'on')
+                is_state("input_boolean.lounge_lights_tv_aware", "on") and (
+                  is_state('remote.lounge_streamer', 'on') or
+                  is_state('media_player.lounge_streamer', 'on') or
+                  is_state('media_player.lounge_streamer_2', 'on')
+                )
               }}
 
             then:

--- a/entities/input_boolean/lounge_lights_tv_aware.yaml
+++ b/entities/input_boolean/lounge_lights_tv_aware.yaml
@@ -1,0 +1,4 @@
+---
+name: "Lounge | Lights: TV Aware"
+
+icon: mdi:television-ambient-light

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -3837,7 +3837,7 @@ File: [`device_tracker/luci/openwrt_vm.yaml`](entities/device_tracker/luci/openw
 
 ## Input Boolean
 
-<details><summary><h3>Entities (50)</h3></summary>
+<details><summary><h3>Entities (51)</h3></summary>
 
 <details><summary><strong>Air Purifier | Quiet Mode</strong></summary>
 
@@ -4251,6 +4251,15 @@ File: [`input_boolean/habit/will_habit_binary_9.yaml`](entities/input_boolean/ha
 - Icon: [`mdi:dumbbell`](https://pictogrammers.com/library/mdi/icon/dumbbell/)
 
 File: [`input_boolean/lounge_lights_exercise_mode.yaml`](entities/input_boolean/lounge_lights_exercise_mode.yaml)
+</details>
+
+<details><summary><strong>Lounge | Lights: TV Aware</strong></summary>
+
+**Entity ID: `input_boolean.lounge_lights_tv_aware`**
+
+- Icon: [`mdi:television-ambient-light`](https://pictogrammers.com/library/mdi/icon/television-ambient-light/)
+
+File: [`input_boolean/lounge_lights_tv_aware.yaml`](entities/input_boolean/lounge_lights_tv_aware.yaml)
 </details>
 
 <details><summary><strong>Mini CRT Fan</strong></summary>


### PR DESCRIPTION


---



- 19c29b2 | Config for TV-aware lighting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "TV Aware" toggle to control lounge lighting behavior based on TV streaming activity.

* **Improvements**
  * Refined lounge occupancy detection logic to require explicit TV-aware mode activation before responding to streaming devices, providing better control over automation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->