### PR TITLE
Add automation for spare room radiator temperature control

### DIFF
--- a/entities/automation/sensor/kitchen_air_quality_sensor_temperature/sync_radiator_trv.yaml
+++ b/entities/automation/sensor/kitchen_air_quality_sensor_temperature/sync_radiator_trv.yaml
@@ -19,7 +19,7 @@ action:
   - service: number.set_value
     target:
       entity_id:
-        - number.kitchen_radiator_external_temperature_input
+        # - number.kitchen_radiator_external_temperature_input
         - number.dining_area_radiator_external_temperature_input
     data:
       value: "{{ states('sensor.kitchen_air_quality_sensor_temperature') | float }}"

--- a/entities/automation/sensor/spare_room_climate_sensor_temperature/sync_radiator_trv.yaml
+++ b/entities/automation/sensor/spare_room_climate_sensor_temperature/sync_radiator_trv.yaml
@@ -1,0 +1,23 @@
+---
+alias: /sensor/spare-room-climate-sensor-temperature/sync-radiator-trv
+
+id: sensor_spare_room_climate_sensor_temperature_sync_radiator_trv
+
+description: >-
+  Sync radiator TRV external temperature input when spare room climate sensor temperature updates
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: sensor.spare_room_climate_sensor_temperature
+    not_to:
+      - "unavailable"
+      - "unknown"
+
+action:
+  - service: number.set_value
+    target:
+      entity_id: number.spare_room_radiator_external_temperature_input
+    data:
+      value: "{{ states('sensor.spare_room_climate_sensor_temperature') | float }}"

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (236)</h3></summary>
+<details><summary><h3>Entities (237)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -3120,6 +3120,19 @@ File: [`automation/sensor/kitchen_air_quality_sensor_temperature/sync_radiator_t
 }
 ```
 File: [`automation/sensor/lighting_modifier/state.yaml`](entities/automation/sensor/lighting_modifier/state.yaml)
+</details>
+
+<details><summary><code>/sensor/spare-room-climate-sensor-temperature/sync-radiator-trv</code></summary>
+
+**Entity ID: `automation.sensor_spare_room_climate_sensor_temperature_sync_radiator_trv`**
+
+> Sync radiator TRV external temperature input when spare room climate sensor temperature updates
+
+- Alias: /sensor/spare-room-climate-sensor-temperature/sync-radiator-trv
+- ID: `sensor_spare_room_climate_sensor_temperature_sync_radiator_trv`
+- Mode: `single`
+
+File: [`automation/sensor/spare_room_climate_sensor_temperature/sync_radiator_trv.yaml`](entities/automation/sensor/spare_room_climate_sensor_temperature/sync_radiator_trv.yaml)
 </details>
 
 <details><summary><code>/sensor/storage-cc-ssd-transient-qbt-disk-used-percentage-notify-and-clear</code></summary>


### PR DESCRIPTION


---



- 88aee41 | Add automation for spare room radiator temperature control


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic temperature synchronization from spare room climate sensor to radiator thermostat valve control.

* **Updates**
  * Modified kitchen radiator automation configuration to sync exclusively with dining area temperature sensor for improved climate management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->