### PR TITLE
Update air purifier quiet mode trigger

### DIFF
--- a/entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml
+++ b/entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml
@@ -9,14 +9,14 @@ max_exceeded: silent
 
 trigger:
   - platform: state
-    entity_id: remote.lounge_tv
-    id: lounge_tv_state
+    entity_id: remote.lounge_streamer
+    id: lounge_streamer_state
     to:
       - "on"
       - "off"
 
 variables:
-  tv_is_on: "{{ states('remote.lounge_tv') | bool(false) }}"
+  tv_is_on: "{{ states('remote.lounge_streamer') | bool(false) }}"
 
 action:
   - service: input_boolean.turn_{{ 'on' if tv_is_on else 'off' }}

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -857,7 +857,7 @@ File: [`automation/input_boolean/air_purifier_quiet_mode/state_change.yaml`](ent
 
 ```json
 {
-  "tv_is_on": "{{ states('remote.lounge_tv') | bool(false) }}"
+  "tv_is_on": "{{ states('remote.lounge_streamer') | bool(false) }}"
 }
 ```
 File: [`automation/input_boolean/air_purifier_quiet_mode/toggle.yaml`](entities/automation/input_boolean/air_purifier_quiet_mode/toggle.yaml)


### PR DESCRIPTION


---



- 61c4aac | Update air purifier quiet mode trigger


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated device references and trigger configuration in home automation settings. The automation trigger sources have been reconfigured to reflect updated hardware while maintaining all existing control logic and behavior patterns. All automation functionality remains unchanged, and no adjustments to user-facing features have been made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->