### PR TITLE
Add air purifier fan speed percentage template sensor

### DIFF
--- a/entities/template/sensor/air_purifier_fan_speed_percentage.yaml
+++ b/entities/template/sensor/air_purifier_fan_speed_percentage.yaml
@@ -4,12 +4,13 @@ name: Air Purifier Fan Speed Percentage
 unique_id: air_purifier_fan_speed_percentage
 
 state: >-
+  {% set pct = state_attr('fan.air_purifier', 'percentage') | int(0) %}
   {% if not states("fan.air_purifier") | bool(false) %}
     0
   {% elif state_attr('fan.air_purifier', 'mode') == 'off' %}
     0
   {% else %}
-    {{ state_attr('fan.air_purifier', 'percentage') | int(0) }}
+    {{ pct }}
   {% endif %}
 
 state_class: measurement
@@ -17,15 +18,18 @@ state_class: measurement
 unit_of_measurement: "%"
 
 icon: >-
+  {% set pct = state_attr('fan.air_purifier', 'percentage') | int(0) %}
   {% if not states("fan.air_purifier") | bool(false) %}
     mdi:fan-off
   {% elif state_attr('fan.air_purifier', 'mode') == 'off' %}
     mdi:fan-off
-  {% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 25 %}
+  {% elif pct <= 0 %}
+    mdi:fan-off
+  {% elif pct <= 25 %}
     mdi:fan-speed-1
-  {% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 50 %}
+  {% elif pct <= 50 %}
     mdi:fan-speed-2
-  {% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 75 %}
+  {% elif pct <= 75 %}
     mdi:fan-speed-3
   {% else %}
     mdi:fan

--- a/entities/template/sensor/air_purifier_fan_speed_percentage.yaml
+++ b/entities/template/sensor/air_purifier_fan_speed_percentage.yaml
@@ -1,0 +1,32 @@
+---
+name: Air Purifier Fan Speed Percentage
+
+unique_id: air_purifier_fan_speed_percentage
+
+state: >-
+  {% if not states("fan.air_purifier") | bool(false) %}
+    0
+  {% elif state_attr('fan.air_purifier', 'mode') == 'off' %}
+    0
+  {% else %}
+    {{ state_attr('fan.air_purifier', 'percentage') | int(0) }}
+  {% endif %}
+
+state_class: measurement
+
+unit_of_measurement: "%"
+
+icon: >-
+  {% if not states("fan.air_purifier") | bool(false) %}
+    mdi:fan-off
+  {% elif state_attr('fan.air_purifier', 'mode') == 'off' %}
+    mdi:fan-off
+  {% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 25 %}
+    mdi:fan-speed-1
+  {% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 50 %}
+    mdi:fan-speed-2
+  {% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 75 %}
+    mdi:fan-speed-3
+  {% else %}
+    mdi:fan
+  {% endif %}

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -10481,15 +10481,17 @@ File: [`template/sensor/air_purifier_fan_speed.yaml`](entities/template/sensor/a
 - Icon:
 
 ```jinja
-{% if not states("fan.air_purifier") | bool(false) %}
+{% set pct = state_attr('fan.air_purifier', 'percentage') | int(0) %} {% if not states("fan.air_purifier") | bool(false) %}
   mdi:fan-off
 {% elif state_attr('fan.air_purifier', 'mode') == 'off' %}
   mdi:fan-off
-{% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 25 %}
+{% elif pct <= 0 %}
+  mdi:fan-off
+{% elif pct <= 25 %}
   mdi:fan-speed-1
-{% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 50 %}
+{% elif pct <= 50 %}
   mdi:fan-speed-2
-{% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 75 %}
+{% elif pct <= 75 %}
   mdi:fan-speed-3
 {% else %}
   mdi:fan

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -10090,7 +10090,7 @@ File: [`sql/mood/will_mood_streak.yaml`](entities/sql/mood/will_mood_streak.yaml
 
 ## Template
 
-<details><summary><h3>Entities (91)</h3></summary>
+<details><summary><h3>Entities (92)</h3></summary>
 
 <details><summary><strong>Bank Holiday</strong></summary>
 
@@ -10472,6 +10472,33 @@ File: [`template/sensor/address_line_1.yaml`](entities/template/sensor/address_l
 {% endif %}
 ```
 File: [`template/sensor/air_purifier_fan_speed.yaml`](entities/template/sensor/air_purifier_fan_speed.yaml)
+</details>
+
+<details><summary><strong>Air Purifier Fan Speed Percentage</strong></summary>
+
+**Entity ID: `sensor.air_purifier_fan_speed_percentage`**
+
+- Icon:
+
+```jinja
+{% if not states("fan.air_purifier") | bool(false) %}
+  mdi:fan-off
+{% elif state_attr('fan.air_purifier', 'mode') == 'off' %}
+  mdi:fan-off
+{% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 25 %}
+  mdi:fan-speed-1
+{% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 50 %}
+  mdi:fan-speed-2
+{% elif state_attr('fan.air_purifier', 'percentage') | int(0) <= 75 %}
+  mdi:fan-speed-3
+{% else %}
+  mdi:fan
+{% endif %}
+```
+
+- Unit Of Measurement: %
+
+File: [`template/sensor/air_purifier_fan_speed_percentage.yaml`](entities/template/sensor/air_purifier_fan_speed_percentage.yaml)
 </details>
 
 <details><summary><strong>Current Hour</strong></summary>


### PR DESCRIPTION


---



- 554be2f | Add air purifier fan speed percentage template sensor
- 637b15c | Refine fan speed template logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Air Purifier Fan Speed Percentage sensor that reports fan speed as a percentage (%). It returns 0% when the fan is off or unavailable, and otherwise reflects the computed integer percentage. The sensor includes measurement state classification and a dynamic icon that changes to reflect off/low/medium/high fan speed ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->