### PR TITLE
Add actionable habit notifications

### DIFF
--- a/dev_tools/generate_habit_files.py
+++ b/dev_tools/generate_habit_files.py
@@ -3,15 +3,38 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 REPO_PATH = Path(__file__).parents[1]
+STATE_FILE = Path(__file__).parent / "habit_counts.json"
 
 if REPO_PATH.name != "home-assistant" or not REPO_PATH.is_dir():
     raise RuntimeError(
         "Unable to locate the `home-assistant` repository."
         f" Current path is: {REPO_PATH!s}",
     )
+
+
+def load_state() -> dict[str, dict[str, int]]:
+    """Load previously saved habit counts from state file.
+
+    Returns:
+        Nested dict of {user: {habit_type: count}}, empty if file doesn't exist.
+    """
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())  # type: ignore[no-any-return]
+    return {}
+
+
+def save_state(state: dict[str, dict[str, int]]) -> None:
+    """Persist habit counts to state file.
+
+    Args:
+        state: Nested dict of {user: {habit_type: count}}.
+    """
+    STATE_FILE.write_text(json.dumps(state, indent=2) + "\n")
+    print(f"  ✓ Saved state to {STATE_FILE}")
 
 
 def generate_binary_habit_files(user: str, total_count: int) -> None:
@@ -699,15 +722,14 @@ def generate_binary_habit_notification_action_files(user: str, total_count: int)
     )
     automation_path.parent.mkdir(parents=True, exist_ok=True)
 
-    trigger_lines = []
-    for num in range(1, total_count + 1):
-        trigger_lines.append(
-            f"  - platform: event\n"
-            f"    event_type: mobile_app_notification_action\n"
-            f"    event_data:\n"
-            f"      action: MARK_HABIT_AS_COMPLETE__{user.upper()}__BINARY_{num}\n"
-            f'    id: "{num}"',
-        )
+    trigger_lines = [
+        f"  - platform: event\n"
+        f"    event_type: mobile_app_notification_action\n"
+        f"    event_data:\n"
+        f"      action: MARK_HABIT_AS_COMPLETE__{user.upper()}__BINARY_{num}\n"
+        f'    id: "{num}"'
+        for num in range(1, total_count + 1)
+    ]
     triggers = "\n\n".join(trigger_lines)
 
     content = f"""---
@@ -755,15 +777,14 @@ def generate_countable_habit_notification_action_files(
     )
     automation_path.parent.mkdir(parents=True, exist_ok=True)
 
-    trigger_lines = []
-    for num in range(1, total_count + 1):
-        trigger_lines.append(
-            f"  - platform: event\n"
-            f"    event_type: mobile_app_notification_action\n"
-            f"    event_data:\n"
-            f"      action: INCREMENT_HABIT__{user.upper()}__COUNTABLE_{num}\n"
-            f'    id: "{num}"',
-        )
+    trigger_lines = [
+        f"  - platform: event\n"
+        f"    event_type: mobile_app_notification_action\n"
+        f"    event_data:\n"
+        f"      action: INCREMENT_HABIT__{user.upper()}__COUNTABLE_{num}\n"
+        f'    id: "{num}"'
+        for num in range(1, total_count + 1)
+    ]
     triggers = "\n\n".join(trigger_lines)
 
     content = f"""---
@@ -891,6 +912,36 @@ state: >-
     print(f"  ✓ Generated high-level habit template sensors for {user}")
 
 
+def _run_for_user(
+    user: str,
+    binary_count: int | None,
+    countable_count: int | None,
+    *,
+    mood: bool,
+) -> None:
+    """Run all generators for a single user.
+
+    Args:
+        user: User name (e.g., 'will').
+        binary_count: Number of binary habits to generate, or None to skip.
+        countable_count: Number of countable habits to generate, or None to skip.
+        mood: Whether to generate mood files.
+    """
+    if binary_count is not None:
+        generate_binary_habit_files(user, binary_count)
+        generate_binary_habit_notification_action_files(user, binary_count)
+
+    if countable_count is not None:
+        generate_countable_habit_files(user, countable_count)
+        generate_countable_habit_notification_action_files(user, countable_count)
+
+    if binary_count is not None or countable_count is not None:
+        generate_habit_template_sensors(user)
+
+    if mood:
+        generate_mood_files(user)
+
+
 def main() -> None:
     """Run the habit file generator."""
     parser = argparse.ArgumentParser(
@@ -898,25 +949,32 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python generate_habit_files.py --user=will --binary 3
+  python generate_habit_files.py --user=will --binary 10
   python generate_habit_files.py --user=will --countable 2
-  python generate_habit_files.py --user=will --binary --countable 5
+  python generate_habit_files.py --user=will --binary 10 --countable 2
+  python generate_habit_files.py --user=will --binary   # uses last saved count
+  python generate_habit_files.py --regenerate-all       # regenerate everything from saved state
         """,
     )
     parser.add_argument(
         "--user",
-        required=True,
-        help="User name (e.g., 'will')",
+        help="User name (e.g., 'will') — not required with --regenerate-all",
     )
     parser.add_argument(
         "--binary",
-        action="store_true",
-        help="Generate binary habits",
+        type=int,
+        nargs="?",
+        const=-1,
+        metavar="COUNT",
+        help="Generate binary habits; omit COUNT to reuse last saved count",
     )
     parser.add_argument(
         "--countable",
-        action="store_true",
-        help="Generate countable habits",
+        type=int,
+        nargs="?",
+        const=-1,
+        metavar="COUNT",
+        help="Generate countable habits; omit COUNT to reuse last saved count",
     )
     parser.add_argument(
         "--mood",
@@ -924,41 +982,91 @@ Examples:
         help="Generate mood tracking files",
     )
     parser.add_argument(
-        "count",
-        type=int,
-        nargs="?",
-        help="Total number of habits desired (required if --binary or --countable is specified)",
+        "--regenerate-all",
+        action="store_true",
+        help="Regenerate all files for all users/types using saved state (ignores other flags)",
     )
 
     args = parser.parse_args()
+    state = load_state()
 
-    if not args.binary and not args.countable and not args.mood:
+    if args.regenerate_all:
+        if not state:
+            parser.error(
+                f"No saved state found at {STATE_FILE}. "
+                "Run with explicit args first to build the state.",
+            )
+        print(f"Regenerating all files from saved state ({STATE_FILE})...")
+        for user, user_state in state.items():
+            print(f"\n--- {user} ---")
+            _run_for_user(
+                user=user,
+                binary_count=user_state.get("binary"),
+                countable_count=user_state.get("countable"),
+                mood=bool(user_state.get("mood", False)),
+            )
+        print("\n✓ Regeneration complete")
+        return
+
+    if not args.user:
+        parser.error("--user is required unless --regenerate-all is specified")
+
+    if args.binary is None and args.countable is None and not args.mood:
         parser.error(
-            "At least one of --binary, --countable, or --mood must be specified",
+            "At least one of --binary, --countable, --mood, or --regenerate-all must be specified",
         )
 
-    if (args.binary or args.countable) and args.count is None:
-        parser.error("Count is required when --binary or --countable is specified")
-
-    if args.count is not None and args.count < 1:
-        parser.error("Count must be a positive integer")
-
     user = args.user.lower()
+    user_state = state.setdefault(user, {})
 
-    if args.binary:
-        generate_binary_habit_files(user, args.count)
-        generate_binary_habit_notification_action_files(user, args.count)
+    binary_count: int | None = None
+    countable_count: int | None = None
 
-    if args.countable:
-        generate_countable_habit_files(user, args.count)
-        generate_countable_habit_notification_action_files(user, args.count)
+    if args.binary is not None:
+        if args.binary == -1:
+            if "binary" in user_state:
+                binary_count = user_state["binary"]
+                print(f"Using saved binary count for {user}: {binary_count}")
+            else:
+                parser.error(
+                    f"No count provided and no saved state for {user}/binary. "
+                    "Provide a count explicitly, e.g. --binary 10",
+                )
+        else:
+            if args.binary < 1:
+                parser.error("--binary count must be a positive integer")
+            binary_count = args.binary
 
-    if args.binary or args.countable:
-        generate_habit_template_sensors(user)
+    if args.countable is not None:
+        if args.countable == -1:
+            if "countable" in user_state:
+                countable_count = user_state["countable"]
+                print(f"Using saved countable count for {user}: {countable_count}")
+            else:
+                parser.error(
+                    f"No count provided and no saved state for {user}/countable. "
+                    "Provide a count explicitly, e.g. --countable 2",
+                )
+        else:
+            if args.countable < 1:
+                parser.error("--countable count must be a positive integer")
+            countable_count = args.countable
 
+    _run_for_user(
+        user=user,
+        binary_count=binary_count,
+        countable_count=countable_count,
+        mood=args.mood,
+    )
+
+    if binary_count is not None:
+        user_state["binary"] = binary_count
+    if countable_count is not None:
+        user_state["countable"] = countable_count
     if args.mood:
-        generate_mood_files(user)
+        user_state["mood"] = True
 
+    save_state(state)
     print("\n✓ Generation complete")
 
 

--- a/dev_tools/generate_habit_files.py
+++ b/dev_tools/generate_habit_files.py
@@ -341,6 +341,8 @@ unique_id: {user}_habit_binary_{num}_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(
@@ -1179,6 +1181,8 @@ name: {user.title()} | Mood Streak
 unique_id: {user}_mood_streak
 
 icon: mdi:fire
+
+unit_of_measurement: days
 
 query: >-
   WITH daily_last_states AS (

--- a/dev_tools/generate_habit_files.py
+++ b/dev_tools/generate_habit_files.py
@@ -351,80 +351,69 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.{user}_habit_binary_{num}'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak
 """

--- a/dev_tools/generate_habit_files.py
+++ b/dev_tools/generate_habit_files.py
@@ -248,12 +248,15 @@ variables:
     }}}}
 
 action:
-  - service: script.notify_XXXUSERXXX
+  - action: script.notify_XXXUSERXXX
     data:
       title: "Habit Reminder"
       message: "Don't forget to mark {{{{ habit_name }}}} as complete!"
       notification_id: XXXUSERXXX_habit_binary_XXXNUMXXX_reminder
       url: /home-XXXUSERXXX/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__XXXUSERUPPERXXX__BINARY_XXXNUMXXX"
+          title: "Mark as Complete"
 
   - if: "{{{{ repeat_reminder_count | int(0) > 0 }}}}"
     then:
@@ -276,12 +279,15 @@ action:
             - delay:
                 minutes: "{{{{ repeat_interval | int(60) }}}}"
 
-            - service: script.notify_XXXUSERXXX
+            - action: script.notify_XXXUSERXXX
               data:
                 title: "Habit Reminder"
                 message: "Don't forget to mark {{{{ habit_name }}}} as complete!"
                 notification_id: XXXUSERXXX_habit_binary_XXXNUMXXX_reminder
                 url: /home-XXXUSERXXX/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__XXXUSERUPPERXXX__BINARY_XXXNUMXXX"
+                    title: "Mark as Complete"
 """  # noqa: E501
         reminder_content = (
             reminder_template
@@ -289,6 +295,7 @@ action:
             .replace("}}}}", "}}")
             .replace("XXXJINJA2SETSTARTXXX", "{%")
             .replace("XXXJINJA2SETENDXXX", "%}")
+            .replace("XXXUSERUPPERXXX", user.upper())
             .replace("XXXUSERXXX", user)
             .replace("XXXNUMXXX", str(num))
             .replace("XXXUSERTITLEXXX", user.title())
@@ -614,12 +621,15 @@ variables:
     "{{{{ states('input_number.XXXUSERXXX_habit_countable_XXXNUMXXX_repeat_reminder_count') | int(0) }}}}"
 
 action:
-  - service: script.notify_XXXUSERXXX
+  - action: script.notify_XXXUSERXXX
     data:
       title: "Habit Reminder"
       message: "Don't forget to track {{{{ habit_name }}}}!"
       notification_id: XXXUSERXXX_habit_countable_XXXNUMXXX_reminder
       url: /home-XXXUSERXXX/mood-habits
+      actions:
+        - action: "INCREMENT_HABIT__XXXUSERUPPERXXX__COUNTABLE_XXXNUMXXX"
+          title: "Increment"
 
   - if: "{{{{ repeat_reminder_count | int(0) > 0 }}}}"
     then:
@@ -642,12 +652,15 @@ action:
             - delay:
                 minutes: "{{{{ repeat_interval | int(60) }}}}"
 
-            - service: script.notify_XXXUSERXXX
+            - action: script.notify_XXXUSERXXX
               data:
                 title: "Habit Reminder"
                 message: "Don't forget to track {{{{ habit_name }}}}!"
                 notification_id: XXXUSERXXX_habit_countable_XXXNUMXXX_reminder
                 url: /home-XXXUSERXXX/mood-habits
+                actions:
+                  - action: "INCREMENT_HABIT__XXXUSERUPPERXXX__COUNTABLE_XXXNUMXXX"
+                    title: "Increment"
 """  # noqa: E501
         reminder_content = (
             reminder_template
@@ -655,6 +668,7 @@ action:
             .replace("}}}}", "}}")
             .replace("XXXJINJA2SETSTARTXXX", "{%")
             .replace("XXXJINJA2SETENDXXX", "%}")
+            .replace("XXXUSERUPPERXXX", user.upper())
             .replace("XXXUSERXXX", user)
             .replace("XXXNUMXXX", str(num))
             .replace("XXXUSERTITLEXXX", user.title())
@@ -662,6 +676,115 @@ action:
         reminder_automation_path.write_text(reminder_content)
 
         print(f"    ✓ Generated files for countable habit {num}")
+
+
+def generate_binary_habit_notification_action_files(user: str, total_count: int) -> None:
+    """Generate a single automation that handles mark-complete actions for all binary habits.
+
+    Args:
+        user: User name (e.g., 'will').
+        total_count: Total number of binary habits (determines number of triggers).
+    """
+    print(f"Generating binary habit notification action automation for {user}...")
+
+    automation_path = (
+        REPO_PATH
+        / "entities"
+        / "automation"
+        / "mobile_app"
+        / "notification_action"
+        / "habit"
+        / f"{user}_habit_binary"
+        / "mark_complete.yaml"
+    )
+    automation_path.parent.mkdir(parents=True, exist_ok=True)
+
+    trigger_lines = []
+    for num in range(1, total_count + 1):
+        trigger_lines.append(
+            f"  - platform: event\n"
+            f"    event_type: mobile_app_notification_action\n"
+            f"    event_data:\n"
+            f"      action: MARK_HABIT_AS_COMPLETE__{user.upper()}__BINARY_{num}\n"
+            f'    id: "{num}"',
+        )
+    triggers = "\n\n".join(trigger_lines)
+
+    content = f"""---
+alias: /mobile-app/notification-action/habit/{user}-habit-binary/mark-complete
+
+id: mobile_app_notification_action_habit_{user}_habit_binary_mark_complete
+
+description: Mark {user.title()}'s binary habits as complete from notification action
+
+mode: parallel
+
+trigger:
+{triggers}
+
+action:
+  - action: input_boolean.turn_on
+    target:
+      entity_id: "input_boolean.{user}_habit_binary_{{{{ trigger.id }}}}"
+"""
+    automation_path.write_text(content)
+    print(f"  ✓ Generated binary habit notification action automation for {user}")
+
+
+def generate_countable_habit_notification_action_files(
+    user: str,
+    total_count: int,
+) -> None:
+    """Generate a single automation that handles increment actions for all countable habits.
+
+    Args:
+        user: User name (e.g., 'will').
+        total_count: Total number of countable habits (determines number of triggers).
+    """
+    print(f"Generating countable habit notification action automation for {user}...")
+
+    automation_path = (
+        REPO_PATH
+        / "entities"
+        / "automation"
+        / "mobile_app"
+        / "notification_action"
+        / "habit"
+        / f"{user}_habit_countable"
+        / "increment.yaml"
+    )
+    automation_path.parent.mkdir(parents=True, exist_ok=True)
+
+    trigger_lines = []
+    for num in range(1, total_count + 1):
+        trigger_lines.append(
+            f"  - platform: event\n"
+            f"    event_type: mobile_app_notification_action\n"
+            f"    event_data:\n"
+            f"      action: INCREMENT_HABIT__{user.upper()}__COUNTABLE_{num}\n"
+            f'    id: "{num}"',
+        )
+    triggers = "\n\n".join(trigger_lines)
+
+    content = f"""---
+alias: /mobile-app/notification-action/habit/{user}-habit-countable/increment
+
+id: mobile_app_notification_action_habit_{user}_habit_countable_increment
+
+description: Increment {user.title()}'s countable habits from notification action
+
+mode: parallel
+
+trigger:
+{triggers}
+
+action:
+  - action: input_number.increment
+    target:
+      entity_id: "input_number.{user}_habit_countable_{{{{ trigger.id }}}}"
+"""
+    automation_path.write_text(content)
+    print(f"  ✓ Generated countable habit notification action automation for {user}")
 
 
 def generate_habit_template_sensors(user: str) -> None:
@@ -824,9 +947,11 @@ Examples:
 
     if args.binary:
         generate_binary_habit_files(user, args.count)
+        generate_binary_habit_notification_action_files(user, args.count)
 
     if args.countable:
         generate_countable_habit_files(user, args.count)
+        generate_countable_habit_notification_action_files(user, args.count)
 
     if args.binary or args.countable:
         generate_habit_template_sensors(user)
@@ -903,7 +1028,7 @@ trigger:
     at: "00:00:00"
 
 action:
-  - service: input_select.select_option
+  - action: input_select.select_option
     target:
       entity_id: input_select.{user}_mood_today
     data:
@@ -937,7 +1062,7 @@ trigger:
     at: "00:00:00"
 
 action:
-  - service: input_text.set_value
+  - action: input_text.set_value
     target:
       entity_id: input_text.{user}_mood_note
     data:

--- a/entities/automation/input_datetime/habit/vic_habit_binary_1/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_1/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_1_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_1"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_1_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_1"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_10/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_10/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_10_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_10"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_10_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_10"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_2/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_2/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_2_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_2"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_2_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_2"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_3/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_3/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_3_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_3"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_3_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_3"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_4/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_4/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_4_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_4"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_4_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_4"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_5/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_5/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_5_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_5"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_5_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_5"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_6/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_6/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_6_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_6"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_6_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_6"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_7/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_7/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_7_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_7"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_7_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_7"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_8/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_8/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_8_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_8"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_8_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_8"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/vic_habit_binary_9/reminder.yaml
+++ b/entities/automation/input_datetime/habit/vic_habit_binary_9/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: vic_habit_binary_9_reminder
       url: /home-vic/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_9"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: vic_habit_binary_9_reminder
                 url: /home-vic/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__VIC__BINARY_9"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_1/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_1/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_1_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_1"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_1_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_1"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_10/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_10/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_10_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_10"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_10_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_10"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_2/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_2/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_2_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_2"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_2_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_2"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_3/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_3/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_3_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_3"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_3_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_3"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_4/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_4/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_4_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_4"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_4_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_4"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_5/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_5/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_5_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_5"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_5_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_5"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_6/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_6/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_6_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_6"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_6_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_6"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_7/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_7/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_7_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_7"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_7_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_7"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_8/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_8/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_8_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_8"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_8_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_8"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_binary_9/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_binary_9/reminder.yaml
@@ -39,6 +39,9 @@ action:
       message: "Don't forget to mark {{ habit_name }} as complete!"
       notification_id: will_habit_binary_9_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_9"
+          title: "Mark as Complete"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -67,3 +70,6 @@ action:
                 message: "Don't forget to mark {{ habit_name }} as complete!"
                 notification_id: will_habit_binary_9_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "MARK_HABIT_AS_COMPLETE__WILL__BINARY_9"
+                    title: "Mark as Complete"

--- a/entities/automation/input_datetime/habit/will_habit_countable_1/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_countable_1/reminder.yaml
@@ -33,6 +33,9 @@ action:
       message: "Don't forget to track {{ habit_name }}!"
       notification_id: will_habit_countable_1_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "INCREMENT_HABIT__WILL__COUNTABLE_1"
+          title: "Increment"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -61,3 +64,6 @@ action:
                 message: "Don't forget to track {{ habit_name }}!"
                 notification_id: will_habit_countable_1_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "INCREMENT_HABIT__WILL__COUNTABLE_1"
+                    title: "Increment"

--- a/entities/automation/input_datetime/habit/will_habit_countable_2/reminder.yaml
+++ b/entities/automation/input_datetime/habit/will_habit_countable_2/reminder.yaml
@@ -33,6 +33,9 @@ action:
       message: "Don't forget to track {{ habit_name }}!"
       notification_id: will_habit_countable_2_reminder
       url: /home-will/mood-habits
+      actions:
+        - action: "INCREMENT_HABIT__WILL__COUNTABLE_2"
+          title: "Increment"
 
   - if: "{{ repeat_reminder_count | int(0) > 0 }}"
     then:
@@ -61,3 +64,6 @@ action:
                 message: "Don't forget to track {{ habit_name }}!"
                 notification_id: will_habit_countable_2_reminder
                 url: /home-will/mood-habits
+                actions:
+                  - action: "INCREMENT_HABIT__WILL__COUNTABLE_2"
+                    title: "Increment"

--- a/entities/automation/mobile_app/notification_action/habit/vic_habit_binary/mark_complete.yaml
+++ b/entities/automation/mobile_app/notification_action/habit/vic_habit_binary/mark_complete.yaml
@@ -1,0 +1,74 @@
+---
+alias: /mobile-app/notification-action/habit/vic-habit-binary/mark-complete
+
+id: mobile_app_notification_action_habit_vic_habit_binary_mark_complete
+
+description: Mark Vic's binary habits as complete from notification action
+
+mode: parallel
+
+trigger:
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_1
+    id: "1"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_2
+    id: "2"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_3
+    id: "3"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_4
+    id: "4"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_5
+    id: "5"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_6
+    id: "6"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_7
+    id: "7"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_8
+    id: "8"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_9
+    id: "9"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__VIC__BINARY_10
+    id: "10"
+
+action:
+  - action: input_boolean.turn_on
+    target:
+      entity_id: "input_boolean.vic_habit_binary_{{ trigger.id }}"

--- a/entities/automation/mobile_app/notification_action/habit/will_habit_binary/mark_complete.yaml
+++ b/entities/automation/mobile_app/notification_action/habit/will_habit_binary/mark_complete.yaml
@@ -1,0 +1,74 @@
+---
+alias: /mobile-app/notification-action/habit/will-habit-binary/mark-complete
+
+id: mobile_app_notification_action_habit_will_habit_binary_mark_complete
+
+description: Mark Will's binary habits as complete from notification action
+
+mode: parallel
+
+trigger:
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_1
+    id: "1"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_2
+    id: "2"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_3
+    id: "3"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_4
+    id: "4"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_5
+    id: "5"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_6
+    id: "6"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_7
+    id: "7"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_8
+    id: "8"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_9
+    id: "9"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: MARK_HABIT_AS_COMPLETE__WILL__BINARY_10
+    id: "10"
+
+action:
+  - action: input_boolean.turn_on
+    target:
+      entity_id: "input_boolean.will_habit_binary_{{ trigger.id }}"

--- a/entities/automation/mobile_app/notification_action/habit/will_habit_countable/increment.yaml
+++ b/entities/automation/mobile_app/notification_action/habit/will_habit_countable/increment.yaml
@@ -1,0 +1,26 @@
+---
+alias: /mobile-app/notification-action/habit/will-habit-countable/increment
+
+id: mobile_app_notification_action_habit_will_habit_countable_increment
+
+description: Increment Will's countable habits from notification action
+
+mode: parallel
+
+trigger:
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: INCREMENT_HABIT__WILL__COUNTABLE_1
+    id: "1"
+
+  - platform: event
+    event_type: mobile_app_notification_action
+    event_data:
+      action: INCREMENT_HABIT__WILL__COUNTABLE_2
+    id: "2"
+
+action:
+  - action: input_number.increment
+    target:
+      entity_id: "input_number.will_habit_countable_{{ trigger.id }}"

--- a/entities/sql/habit/vic_habit_binary_10_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_10_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_10'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_10_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_10_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_10_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_10_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_10_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 10 Streak
+
+unique_id: vic_habit_binary_10_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_10_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_10'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_1_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_1_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_1'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_1_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_1_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 1 Streak
+
+unique_id: vic_habit_binary_1_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_1_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_1'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_1_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_1_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_1_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_2_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_2_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 2 Streak
+
+unique_id: vic_habit_binary_2_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_2_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_2'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_2_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_2_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_2'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_2_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_2_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_2_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_3_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_3_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_3_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_3_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_3_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 3 Streak
+
+unique_id: vic_habit_binary_3_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_3_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_3'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_3_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_3_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_3'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_4_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_4_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 4 Streak
+
+unique_id: vic_habit_binary_4_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_4_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_4'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_4_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_4_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_4_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_4_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_4_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_4'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_5_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_5_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_5_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_5_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_5_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_5'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_5_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_5_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 5 Streak
+
+unique_id: vic_habit_binary_5_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_5_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_5'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_6_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_6_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_6'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_6_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_6_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 6 Streak
+
+unique_id: vic_habit_binary_6_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_6_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_6'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_6_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_6_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_6_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_7_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_7_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_7'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_7_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_7_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_7_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_7_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_7_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 7 Streak
+
+unique_id: vic_habit_binary_7_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_7_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_7'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_8_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_8_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_8'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_8_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_8_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_8_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_8_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_8_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 8 Streak
+
+unique_id: vic_habit_binary_8_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_8_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_8'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/vic_habit_binary_9_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_9_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_9'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/vic_habit_binary_9_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_9_streak.yaml
@@ -5,6 +5,8 @@ unique_id: vic_habit_binary_9_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/vic_habit_binary_9_streak.yaml
+++ b/entities/sql/habit/vic_habit_binary_9_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Vic | Habit Binary 9 Streak
+
+unique_id: vic_habit_binary_9_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.vic_habit_binary_9_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.vic_habit_binary_9'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_10_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_10_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 10 Streak
+
+unique_id: will_habit_binary_10_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_10_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_10'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_10_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_10_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_10_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_10_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_10_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_10'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_1_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_1_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_1_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_1_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_1_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_1'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_1_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_1_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 1 Streak
+
+unique_id: will_habit_binary_1_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_1_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_1'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_2_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_2_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_2_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_2_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_2_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_2'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_2_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_2_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 2 Streak
+
+unique_id: will_habit_binary_2_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_2_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_2'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_3_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_3_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 3 Streak
+
+unique_id: will_habit_binary_3_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_3_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_3'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_3_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_3_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_3_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_3_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_3_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_3'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_4_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_4_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 4 Streak
+
+unique_id: will_habit_binary_4_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_4_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_4'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_4_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_4_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_4'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_4_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_4_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_4_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_5_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_5_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_5_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_5_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_5_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 5 Streak
+
+unique_id: will_habit_binary_5_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_5_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_5'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_5_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_5_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_5'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_6_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_6_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_6_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_6_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_6_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_6'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_6_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_6_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 6 Streak
+
+unique_id: will_habit_binary_6_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_6_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_6'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_7_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_7_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_7'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_7_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_7_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 7 Streak
+
+unique_id: will_habit_binary_7_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_7_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_7'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_7_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_7_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_7_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_8_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_8_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_8_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_8_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_8_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 8 Streak
+
+unique_id: will_habit_binary_8_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_8_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_8'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_8_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_8_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_8'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/entities/sql/habit/will_habit_binary_9_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_9_streak.yaml
@@ -5,6 +5,8 @@ unique_id: will_habit_binary_9_streak
 
 icon: mdi:fire
 
+unit_of_measurement: days
+
 query: >-
   WITH min_days_per_week AS (
     SELECT COALESCE(

--- a/entities/sql/habit/will_habit_binary_9_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_9_streak.yaml
@@ -1,0 +1,93 @@
+---
+name: Will | Habit Binary 9 Streak
+
+unique_id: will_habit_binary_9_streak
+
+icon: mdi:fire
+
+query: >-
+  WITH min_days_per_week AS (
+    SELECT COALESCE(
+      (SELECT (state::numeric)::integer
+       FROM states
+       INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+       WHERE states_meta.entity_id = 'input_number.will_habit_binary_9_streak_min_days_per_week'
+       ORDER BY states.last_updated_ts DESC
+       LIMIT 1),
+      7
+    ) as min_days
+  ),
+  daily_last_states AS (
+    SELECT
+      DATE(to_timestamp(states.last_updated_ts)) as check_date,
+      states.state,
+      states.last_updated_ts,
+      ROW_NUMBER() OVER (
+          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
+          ORDER BY states.last_updated_ts DESC
+      ) as rn
+    FROM states
+    INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
+    WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_9'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
+      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+  ),
+  valid_dates AS (
+    SELECT DISTINCT check_date
+    FROM daily_last_states
+    WHERE rn = 1
+      AND state = 'on'
+  ),
+  week_groups AS (
+    SELECT
+      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
+      COUNT(*) as days_count
+    FROM valid_dates
+    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+  ),
+  yesterday_week_start AS (
+    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
+  ),
+  valid_weeks AS (
+    SELECT
+      wg.week_start,
+      wg.days_count,
+      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
+    FROM week_groups wg
+    CROSS JOIN min_days_per_week mdpw
+    CROSS JOIN yesterday_week_start yws
+    WHERE wg.days_count >= mdpw.min_days
+       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
+  ),
+  ordered_weeks AS (
+    SELECT
+      vw.week_start,
+      vw.days_count,
+      vw.days_ago_week_start,
+      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
+      (EXTRACT(EPOCH FROM (
+        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
+      )) / 86400)::integer as days_since_prev_week
+    FROM valid_weeks vw
+    CROSS JOIN yesterday_week_start yws
+    WHERE vw.week_start <= yws.week_start
+  ),
+  consecutive_week_groups AS (
+    SELECT
+      week_start,
+      days_count,
+      days_ago_week_start,
+      rn,
+      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
+        OVER (ORDER BY week_start DESC) as grp
+    FROM ordered_weeks
+  ),
+  current_streak_weeks AS (
+    SELECT week_start, days_count
+    FROM consecutive_week_groups
+    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+  )
+  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
+  FROM current_streak_weeks
+
+column: streak

--- a/entities/sql/habit/will_habit_binary_9_streak.yaml
+++ b/entities/sql/habit/will_habit_binary_9_streak.yaml
@@ -15,79 +15,68 @@ query: >-
        ORDER BY states.last_updated_ts DESC
        LIMIT 1),
       7
-    ) as min_days
+    ) AS min_days
   ),
-  daily_last_states AS (
+  completed_dates AS (
     SELECT
-      DATE(to_timestamp(states.last_updated_ts)) as check_date,
-      states.state,
-      states.last_updated_ts,
-      ROW_NUMBER() OVER (
-          PARTITION BY DATE(to_timestamp(states.last_updated_ts))
-          ORDER BY states.last_updated_ts DESC
-      ) as rn
+      DATE(to_timestamp(states.last_updated_ts)) AS completed_date
     FROM states
     INNER JOIN states_meta ON states.metadata_id = states_meta.metadata_id
     WHERE states_meta.entity_id = 'input_boolean.will_habit_binary_9'
-      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '365 days'))
-      AND DATE(to_timestamp(states.last_updated_ts)) < CURRENT_DATE
+      AND states.state = 'on'
+      AND states.last_updated_ts >= EXTRACT(EPOCH FROM (CURRENT_DATE - INTERVAL '366 days'))
+    GROUP BY DATE(to_timestamp(states.last_updated_ts))
   ),
-  valid_dates AS (
-    SELECT DISTINCT check_date
-    FROM daily_last_states
-    WHERE rn = 1
-      AND state = 'on'
-  ),
-  week_groups AS (
+  streak_anchor AS (
     SELECT
-      DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day' as week_start,
-      COUNT(*) as days_count
-    FROM valid_dates
-    GROUP BY DATE_TRUNC('week', check_date - INTERVAL '1 day') + INTERVAL '1 day'
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM completed_dates
+          WHERE completed_date = CURRENT_DATE
+        )
+        THEN CURRENT_DATE
+        ELSE CURRENT_DATE - INTERVAL '1 day'
+      END::date AS streak_end_date
   ),
-  yesterday_week_start AS (
-    SELECT DATE_TRUNC('week', (CURRENT_DATE - 1) - INTERVAL '1 day') + INTERVAL '1 day' as week_start
-  ),
-  valid_weeks AS (
+  day_series AS (
     SELECT
-      wg.week_start,
-      wg.days_count,
-      EXTRACT(EPOCH FROM ((CURRENT_DATE - 1) - wg.week_start)) / 86400 as days_ago_week_start
-    FROM week_groups wg
+      day_offset,
+      (sa.streak_end_date - day_offset)::date AS check_date
+    FROM streak_anchor sa
+    CROSS JOIN generate_series(0, 365) AS day_offset
+  ),
+  weekly_completion_counts AS (
+    SELECT
+      DATE_TRUNC('week', completed_date)::date AS week_start,
+      COUNT(*)::integer AS completed_days
+    FROM completed_dates
+    GROUP BY DATE_TRUNC('week', completed_date)::date
+  ),
+  streak_candidates AS (
+    SELECT
+      ds.day_offset,
+      ds.check_date,
+      DATE_TRUNC('week', ds.check_date)::date AS check_week_start,
+      DATE_TRUNC('week', sa.streak_end_date)::date AS anchor_week_start,
+      COALESCE(wcc.completed_days, 0) AS completed_days_in_week
+    FROM day_series ds
+    CROSS JOIN streak_anchor sa
+    LEFT JOIN weekly_completion_counts wcc
+      ON wcc.week_start = DATE_TRUNC('week', ds.check_date)::date
+  ),
+  first_incomplete_day AS (
+    SELECT MIN(sc.day_offset) AS first_gap_offset
+    FROM streak_candidates sc
     CROSS JOIN min_days_per_week mdpw
-    CROSS JOIN yesterday_week_start yws
-    WHERE wg.days_count >= mdpw.min_days
-       OR (wg.week_start = yws.week_start AND wg.days_count > 0)
-  ),
-  ordered_weeks AS (
-    SELECT
-      vw.week_start,
-      vw.days_count,
-      vw.days_ago_week_start,
-      ROW_NUMBER() OVER (ORDER BY vw.week_start DESC) as rn,
-      (EXTRACT(EPOCH FROM (
-        vw.week_start - LAG(vw.week_start, 1) OVER (ORDER BY vw.week_start DESC)
-      )) / 86400)::integer as days_since_prev_week
-    FROM valid_weeks vw
-    CROSS JOIN yesterday_week_start yws
-    WHERE vw.week_start <= yws.week_start
-  ),
-  consecutive_week_groups AS (
-    SELECT
-      week_start,
-      days_count,
-      days_ago_week_start,
-      rn,
-      SUM(CASE WHEN days_since_prev_week IS NULL OR days_since_prev_week = 7 THEN 0 ELSE 1 END)
-        OVER (ORDER BY week_start DESC) as grp
-    FROM ordered_weeks
-  ),
-  current_streak_weeks AS (
-    SELECT week_start, days_count
-    FROM consecutive_week_groups
-    WHERE grp = (SELECT grp FROM consecutive_week_groups ORDER BY week_start DESC LIMIT 1)
+    LEFT JOIN completed_dates cd_day ON cd_day.completed_date = sc.check_date
+    WHERE cd_day.completed_date IS NULL
+       OR (
+         sc.check_week_start <> sc.anchor_week_start
+         AND sc.completed_days_in_week < mdpw.min_days
+       )
   )
-  SELECT COALESCE(SUM(days_count)::integer, 0) as streak
-  FROM current_streak_weeks
+  SELECT COALESCE(first_gap_offset, 366)::integer AS streak
+  FROM first_incomplete_day
 
 column: streak

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (237)</h3></summary>
+<details><summary><h3>Entities (240)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -1864,6 +1864,45 @@ File: [`automation/mobile_app/notification_action/bedroom_sunrise_stop.yaml`](en
 - Mode: `single`
 
 File: [`automation/mobile_app/notification_action/central_heating_turn_off.yaml`](entities/automation/mobile_app/notification_action/central_heating_turn_off.yaml)
+</details>
+
+<details><summary><code>/mobile-app/notification-action/habit/vic-habit-binary/mark-complete</code></summary>
+
+**Entity ID: `automation.mobile_app_notification_action_habit_vic_habit_binary_mark_complete`**
+
+> Mark Vic's binary habits as complete from notification action
+
+- Alias: /mobile-app/notification-action/habit/vic-habit-binary/mark-complete
+- ID: `mobile_app_notification_action_habit_vic_habit_binary_mark_complete`
+- Mode: `parallel`
+
+File: [`automation/mobile_app/notification_action/habit/vic_habit_binary/mark_complete.yaml`](entities/automation/mobile_app/notification_action/habit/vic_habit_binary/mark_complete.yaml)
+</details>
+
+<details><summary><code>/mobile-app/notification-action/habit/will-habit-binary/mark-complete</code></summary>
+
+**Entity ID: `automation.mobile_app_notification_action_habit_will_habit_binary_mark_complete`**
+
+> Mark Will's binary habits as complete from notification action
+
+- Alias: /mobile-app/notification-action/habit/will-habit-binary/mark-complete
+- ID: `mobile_app_notification_action_habit_will_habit_binary_mark_complete`
+- Mode: `parallel`
+
+File: [`automation/mobile_app/notification_action/habit/will_habit_binary/mark_complete.yaml`](entities/automation/mobile_app/notification_action/habit/will_habit_binary/mark_complete.yaml)
+</details>
+
+<details><summary><code>/mobile-app/notification-action/habit/will-habit-countable/increment</code></summary>
+
+**Entity ID: `automation.mobile_app_notification_action_habit_will_habit_countable_increment`**
+
+> Increment Will's countable habits from notification action
+
+- Alias: /mobile-app/notification-action/habit/will-habit-countable/increment
+- ID: `mobile_app_notification_action_habit_will_habit_countable_increment`
+- Mode: `parallel`
+
+File: [`automation/mobile_app/notification_action/habit/will_habit_countable/increment.yaml`](entities/automation/mobile_app/notification_action/habit/will_habit_countable/increment.yaml)
 </details>
 
 <details><summary><code>/mtrxpi/content-trigger/audio-visualiser</code></summary>
@@ -10066,7 +10105,187 @@ File: [`shell_command/toggle_pr_label.yaml`](entities/shell_command/toggle_pr_la
 
 ## Sql
 
-<details><summary><h3>Entities (2)</h3></summary>
+<details><summary><h3>Entities (22)</h3></summary>
+
+<details><summary><strong>Vic | Habit Binary 10 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_10_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_10_streak.yaml`](entities/sql/habit/vic_habit_binary_10_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 1 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_1_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_1_streak.yaml`](entities/sql/habit/vic_habit_binary_1_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 2 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_2_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_2_streak.yaml`](entities/sql/habit/vic_habit_binary_2_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 3 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_3_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_3_streak.yaml`](entities/sql/habit/vic_habit_binary_3_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 4 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_4_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_4_streak.yaml`](entities/sql/habit/vic_habit_binary_4_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 5 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_5_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_5_streak.yaml`](entities/sql/habit/vic_habit_binary_5_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 6 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_6_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_6_streak.yaml`](entities/sql/habit/vic_habit_binary_6_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 7 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_7_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_7_streak.yaml`](entities/sql/habit/vic_habit_binary_7_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 8 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_8_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_8_streak.yaml`](entities/sql/habit/vic_habit_binary_8_streak.yaml)
+</details>
+
+<details><summary><strong>Vic | Habit Binary 9 Streak</strong></summary>
+
+**Entity ID: `sql.vic_habit_binary_9_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/vic_habit_binary_9_streak.yaml`](entities/sql/habit/vic_habit_binary_9_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 10 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_10_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_10_streak.yaml`](entities/sql/habit/will_habit_binary_10_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 1 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_1_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_1_streak.yaml`](entities/sql/habit/will_habit_binary_1_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 2 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_2_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_2_streak.yaml`](entities/sql/habit/will_habit_binary_2_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 3 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_3_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_3_streak.yaml`](entities/sql/habit/will_habit_binary_3_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 4 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_4_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_4_streak.yaml`](entities/sql/habit/will_habit_binary_4_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 5 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_5_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_5_streak.yaml`](entities/sql/habit/will_habit_binary_5_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 6 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_6_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_6_streak.yaml`](entities/sql/habit/will_habit_binary_6_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 7 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_7_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_7_streak.yaml`](entities/sql/habit/will_habit_binary_7_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 8 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_8_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_8_streak.yaml`](entities/sql/habit/will_habit_binary_8_streak.yaml)
+</details>
+
+<details><summary><strong>Will | Habit Binary 9 Streak</strong></summary>
+
+**Entity ID: `sql.will_habit_binary_9_streak`**
+
+- Column: `streak`
+
+File: [`sql/habit/will_habit_binary_9_streak.yaml`](entities/sql/habit/will_habit_binary_9_streak.yaml)
+</details>
 
 <details><summary><strong>Vic | Mood Streak</strong></summary>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ lint.ignore = [
 "__init__.py" = ["D104"]
 "dev_tools/**/*.py" = ["T201"]
 "dev_tools/color_generator.py" = ["ERA001"]
+"dev_tools/generate_habit_files.py" = ["PLR0912", "PLR0915", "C901"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 115

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "home-assistant"
-version = "3.23.0"
+version = "3.25.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp-proxy" },


### PR DESCRIPTION


---



- 19bd07d | Add actionable habit notifications
- 10de48d | Add state persistence to habit generator
- 407cabc | Add generated files
- b88b34e | Refine habit streak calculation logic
- 2d1ae71 | Set streak sensor unit to days


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive notification action buttons to habit reminders—users can now mark binary habits complete and increment countable habits directly from notifications without opening the app.
  * Introduced persistent state tracking for habits with configurable regeneration.

* **Improvements**
  * Enhanced streak calculations with configurable weekly minimum thresholds for more accurate habit tracking.
  * Updated reminder notifications with improved Home Assistant integration for better automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->