### PR TITLE
Make door closure timeout configurable

### DIFF
--- a/entities/automation/cosmo/nightly_kitchen_clean.yaml
+++ b/entities/automation/cosmo/nightly_kitchen_clean.yaml
@@ -26,6 +26,10 @@ action:
   - if: "{{ is_state('binary_sensor.kitchen_door_door', 'on') }}"
 
     then:
+      - variables:
+          door_timeout_minutes: >-
+            {{ states('input_number.cosmo_nightly_kitchen_clean_door_close_timeout') | int(60) }}
+
       - alias: Notify Will that the kitchen door is open
         action: script.notify_will
         data:
@@ -35,11 +39,12 @@ action:
             button below.
           notification_id: cosmo_nightly_kitchen_clean_door_open
           mobile_notification_icon: mdi:door-open
+          timeout: "{{ door_timeout_minutes * 60 }}"
           actions:
             - action: COSMO_KITCHEN_CLEAN_ANYWAY
               title: Clean Anyway
 
-      - alias: Wait up to 1 hour for the door to close or for manual override
+      - alias: Wait for the door to close or for manual override
         wait_for_trigger:
           - platform: state
             entity_id: binary_sensor.kitchen_door_door
@@ -49,7 +54,7 @@ action:
             event_data:
               action: COSMO_KITCHEN_CLEAN_ANYWAY
         timeout:
-          hours: 1
+          minutes: "{{ door_timeout_minutes }}"
         continue_on_timeout: true
 
       - alias: Clear the door open notification
@@ -61,7 +66,7 @@ action:
       - if: "{{ not wait.completed }}"
 
         then:
-          - stop: Kitchen door was not closed within 1 hour, skipping clean
+          - stop: Kitchen door was not closed within the timeout, skipping clean
 
   - action: script.cosmo_clean_room
     data:

--- a/entities/input_number/cosmo_nightly_kitchen_clean_door_close_timeout.yaml
+++ b/entities/input_number/cosmo_nightly_kitchen_clean_door_close_timeout.yaml
@@ -1,0 +1,14 @@
+---
+name: "Cosmo Nightly Kitchen Clean: Door Close Timeout"
+
+min: 5
+
+max: 120
+
+step: 5
+
+mode: slider
+
+unit_of_measurement: "min"
+
+icon: mdi:timer-outline

--- a/entities/script/notify_will.yaml
+++ b/entities/script/notify_will.yaml
@@ -80,6 +80,18 @@ fields:
     selector:
       text:
 
+  timeout:
+    description: >-
+      How long (in seconds) the notification should be shown before being auto-dismissed.
+      Only applies to phone notifications.
+    example: "3600"
+    required: false
+    selector:
+      number:
+        min: 0
+        max: 86400
+        unit_of_measurement: s
+
 mode: queued
 
 max: 50
@@ -120,6 +132,8 @@ variables:
   persistent: "{{ persistent | default(false) }}"
 
   image: "{{ image | default('') }}"
+
+  timeout: "{{ timeout | default(None) }}"
 
 sequence:
   - if: >-
@@ -165,6 +179,7 @@ sequence:
         sticky: "{{ sticky }}"
         persistent: "{{ persistent }}"
         image: "{{ image }}"
+        timeout: "{{ timeout }}"
 
   - alias: Personal MacBook Pro
     if:

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4731,7 +4731,7 @@ File: [`input_datetime/rain_flash_cooldown.yaml`](entities/input_datetime/rain_f
 
 ## Input Number
 
-<details><summary><h3>Entities (128)</h3></summary>
+<details><summary><h3>Entities (129)</h3></summary>
 
 <details><summary><strong>Auto-Save Debit Transaction Percentage</strong></summary>
 
@@ -4815,6 +4815,19 @@ File: [`input_number/cc_pot_top_up/credit_card_pot_top_up_maximum_auto_top_up.ya
 - Unit Of Measurement: GBP
 
 File: [`input_number/cc_pot_top_up/credit_card_pot_top_up_minimum_remainder.yaml`](entities/input_number/cc_pot_top_up/credit_card_pot_top_up_minimum_remainder.yaml)
+</details>
+
+<details><summary><strong>Cosmo Nightly Kitchen Clean: Door Close Timeout</strong></summary>
+
+**Entity ID: `input_number.cosmo_nightly_kitchen_clean_door_close_timeout`**
+
+- Icon: [`mdi:timer-outline`](https://pictogrammers.com/library/mdi/icon/timer-outline/)
+- Max: 120
+- Min: 5
+- Mode: `slider`
+- Unit Of Measurement: `min`
+
+File: [`input_number/cosmo_nightly_kitchen_clean_door_close_timeout.yaml`](entities/input_number/cosmo_nightly_kitchen_clean_door_close_timeout.yaml)
 </details>
 
 <details><summary><strong>Dry Box | Max Humidity</strong></summary>
@@ -9588,6 +9601,18 @@ File: [`script/notify_vic.yaml`](entities/script/notify_vic.yaml)
     "selector": {
       "text": null
     }
+  },
+  "timeout": {
+    "description": "How long (in seconds) the notification should be shown before being auto-dismissed. Only applies to phone notifications.",
+    "example": "3600",
+    "required": false,
+    "selector": {
+      "number": {
+        "min": 0,
+        "max": 86400,
+        "unit_of_measurement": "s"
+      }
+    }
   }
 }
 ```
@@ -9607,7 +9632,8 @@ File: [`script/notify_vic.yaml`](entities/script/notify_vic.yaml)
   "group": "{{ group | default('') }}",
   "sticky": "{{ sticky | default(false) }}",
   "persistent": "{{ persistent | default(false) }}",
-  "image": "{{ image | default('') }}"
+  "image": "{{ image | default('') }}",
+  "timeout": "{{ timeout | default(None) }}"
 }
 ```
 File: [`script/notify_will.yaml`](entities/script/notify_will.yaml)


### PR DESCRIPTION


---



- da6a8c3 | Make door closure timeout configurable
- f0e4556 | [pre-commit.ci] auto fixes from pre-commit.com hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kitchen automation door timeout is now user-configurable (5–120 minutes in 5-minute increments; previously fixed at 60 minutes) for greater flexibility.
  * Phone notifications now support custom auto-dismiss timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->