### PR TITLE
Add wind speed protection for roof shutters

### DIFF
--- a/.cursor/rules/home-assistant-dashboard.mdc
+++ b/.cursor/rules/home-assistant-dashboard.mdc
@@ -1,0 +1,10 @@
+---
+description: Rules for Home Assistant dashboard creation, editing, and UI configuration via MCP
+alwaysApply: true
+---
+
+# Home Assistant Dashboard Rules
+
+## mini-graph-card
+
+Never include `grid_options` (e.g. `columns`, `rows`) on a `custom:mini-graph-card` unless the user explicitly requests it. The card manages its own sizing and adding `grid_options` breaks the layout. This applies whether the card is being created fresh or updated.

--- a/entities/input_number/threshold/roof_shutters/roof_shutters_cloud_cover_threshold.yaml
+++ b/entities/input_number/threshold/roof_shutters/roof_shutters_cloud_cover_threshold.yaml
@@ -1,0 +1,12 @@
+---
+name: "Roof Shutters: Cloud Cover Threshold"
+
+min: 10
+
+max: 100
+
+step: 5
+
+mode: box
+
+unit_of_measurement: "%"

--- a/entities/input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml
+++ b/entities/input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml
@@ -1,0 +1,12 @@
+---
+name: "Roof Shutters: Wind Speed Threshold"
+
+min: 1
+
+max: 20
+
+step: 0.5
+
+mode: box
+
+unit_of_measurement: m/s

--- a/entities/input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml
+++ b/entities/input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml
@@ -9,4 +9,4 @@ step: 0.5
 
 mode: box
 
-unit_of_measurement: m/s
+unit_of_measurement: mph

--- a/entities/input_number/threshold/roof_shutters/roof_terrace_window_azimuth_tolerance.yaml
+++ b/entities/input_number/threshold/roof_shutters/roof_terrace_window_azimuth_tolerance.yaml
@@ -1,0 +1,12 @@
+---
+name: "Roof Terrace Window: Azimuth Tolerance"
+
+min: 5
+
+max: 90
+
+step: 5
+
+mode: box
+
+unit_of_measurement: "°"

--- a/entities/input_number/threshold/roof_shutters/roof_terrace_window_bearing.yaml
+++ b/entities/input_number/threshold/roof_shutters/roof_terrace_window_bearing.yaml
@@ -1,0 +1,12 @@
+---
+name: "Roof Terrace Window: Bearing"
+
+min: 0
+
+max: 359
+
+step: 1
+
+mode: box
+
+unit_of_measurement: "°"

--- a/entities/input_number/threshold/roof_shutters/roof_terrace_window_min_elevation.yaml
+++ b/entities/input_number/threshold/roof_shutters/roof_terrace_window_min_elevation.yaml
@@ -1,0 +1,12 @@
+---
+name: "Roof Terrace Window: Min Elevation"
+
+min: 0
+
+max: 45
+
+step: 1
+
+mode: box
+
+unit_of_measurement: "°"

--- a/entities/template/binary_sensor/roof_terrace/roof_shutters_should_be_open.yaml
+++ b/entities/template/binary_sensor/roof_terrace/roof_shutters_should_be_open.yaml
@@ -18,7 +18,7 @@ availability: >-
         not in ['unavailable', 'unknown']
     and states('sensor.landing_climate_sensor_temperature')
         not in ['unavailable', 'unknown']
-    and states('sensor.tomorrow_io_wind_speed')
+    and states('sensor.met_office_fulham_wind_speed')
         not in ['unavailable', 'unknown']
   }}
 
@@ -35,7 +35,7 @@ state: >-
   {% set reopen_t = close_t - delta %}
   {# When open: close once temp >= close_t. When closed: only reopen once temp < reopen_t. #}
   {% set hot = (temp >= close_t) if this.state != 'off' else (temp >= reopen_t) %}
-  {% set wind = states('sensor.tomorrow_io_wind_speed') | float(0) %}
+  {% set wind = states('sensor.met_office_fulham_wind_speed') | float(0) %}
   {% set wind_t = states(
     'input_number.roof_shutters_wind_speed_threshold'
   ) | float(10) %}
@@ -59,7 +59,7 @@ attributes:
       'input_number.roof_shutters_wind_speed_threshold'
     ) | float(10) }}
   current_wind_speed: >-
-    {{ states('sensor.tomorrow_io_wind_speed') | float(0) }}
+    {{ states('sensor.met_office_fulham_wind_speed') | float(0) }}
   sun_above_horizon: "{{ is_state('sun.sun', 'above_horizon') }}"
   window_in_direct_sun: >-
     {{ is_state('binary_sensor.roof_terrace_window_in_direct_sun', 'on') }}

--- a/entities/template/binary_sensor/roof_terrace/roof_shutters_should_be_open.yaml
+++ b/entities/template/binary_sensor/roof_terrace/roof_shutters_should_be_open.yaml
@@ -3,8 +3,9 @@
 # sensor rather than containing their own logic — inspect this to understand why
 # the shutters are in (or should be in) a given position.
 #
-# Hysteresis is implemented via `this.state`: closing uses `close_threshold`,
-# reopening requires temperature to have dropped to `close_threshold - delta`.
+# Temperature hysteresis via `this.state`: closing uses `close_threshold`,
+# reopening requires temperature to drop to `close_threshold - delta`.
+# Wind is a simple threshold: closes when wind speed >= wind_threshold.
 name: Roof Shutters Should Be Open
 unique_id: roof_shutters_should_be_open
 
@@ -16,6 +17,8 @@ availability: >-
     and states('binary_sensor.roof_terrace_window_in_direct_sun')
         not in ['unavailable', 'unknown']
     and states('sensor.landing_climate_sensor_temperature')
+        not in ['unavailable', 'unknown']
+    and states('sensor.tomorrow_io_wind_speed')
         not in ['unavailable', 'unknown']
   }}
 
@@ -32,7 +35,12 @@ state: >-
   {% set reopen_t = close_t - delta %}
   {# When open: close once temp >= close_t. When closed: only reopen once temp < reopen_t. #}
   {% set hot = (temp >= close_t) if this.state != 'off' else (temp >= reopen_t) %}
-  {{ sun_up and not (direct_sun and hot) }}
+  {% set wind = states('sensor.tomorrow_io_wind_speed') | float(0) %}
+  {% set wind_t = states(
+    'input_number.roof_shutters_wind_speed_threshold'
+  ) | float(10) %}
+  {% set too_windy = wind >= wind_t %}
+  {{ sun_up and not (direct_sun and hot) and not too_windy }}
 
 attributes:
   close_temperature_threshold: >-
@@ -46,6 +54,12 @@ attributes:
   hysteresis_delta: 2
   current_temperature: >-
     {{ states('sensor.landing_climate_sensor_temperature') | float(100) }}
+  wind_speed_threshold: >-
+    {{ states(
+      'input_number.roof_shutters_wind_speed_threshold'
+    ) | float(10) }}
+  current_wind_speed: >-
+    {{ states('sensor.tomorrow_io_wind_speed') | float(0) }}
   sun_above_horizon: "{{ is_state('sun.sun', 'above_horizon') }}"
   window_in_direct_sun: >-
     {{ is_state('binary_sensor.roof_terrace_window_in_direct_sun', 'on') }}

--- a/entities/template/binary_sensor/roof_terrace_window_in_direct_sun.yaml
+++ b/entities/template/binary_sensor/roof_terrace_window_in_direct_sun.yaml
@@ -1,6 +1,7 @@
 ---
-# Geometric first pass: vertical window faces ~260°; sun is "direct" when its azimuth
-# is within ±tolerance of that bearing and elevation is above a floor (low sun ignored).
+# Geometric + atmospheric check: vertical window faces ~260°; sun is "direct" when its azimuth
+# is within ±tolerance of that bearing, elevation is above a floor (low sun ignored), and cloud
+# cover is below the configured threshold (overcast skies block meaningful direct sunlight).
 name: Roof Terrace Window in Direct Sun
 
 unique_id: roof_terrace_window_in_direct_sun
@@ -8,6 +9,7 @@ unique_id: roof_terrace_window_in_direct_sun
 icon: mdi:weather-sunny
 
 # Avoid evaluating when sun.sun has no usable attributes (prevents bogus on/off from float defaults).
+# Cloud cover uses float(0) fallback so an unavailable forecast conservatively assumes clear sky.
 availability: "{{ states('sun.sun') not in ['unavailable', 'unknown'] }}"
 
 state: >-
@@ -20,10 +22,15 @@ state: >-
   {% set min_elevation = 10 %}
   {# Smallest signed angle sun_az → window_bearing; % wraps at 360° so ±180° is the max step. #}
   {% set signed_diff = ((sun_az - window_bearing + 180) % 360) - 180 %}
-  {# ON when sun is in front of the window (within cone) and high enough. #}
-  {{ (signed_diff | abs <= azimuth_tolerance) and (sun_el >= min_elevation) }}
+  {# Cloud cover: unavailable sensor defaults to 0% (clear sky) — conservative/safe assumption. #}
+  {% set cloud = states('sensor.tomorrow_io_cloud_cover') | float(0) %}
+  {% set cloud_t = states(
+    'input_number.roof_shutters_cloud_cover_threshold'
+  ) | float(75) %}
+  {# ON when sun is geometrically in front of the window and sky is sufficiently clear. #}
+  {{ (signed_diff | abs <= azimuth_tolerance) and (sun_el >= min_elevation) and (cloud < cloud_t) }}
 
-# Static thresholds for tuning; dynamic sun values mirror state_attr for dashboards/debug.
+# Static thresholds for tuning; dynamic sun/cloud values mirror live data for dashboards/debug.
 attributes:
   window_bearing: 260
 
@@ -31,6 +38,13 @@ attributes:
 
   min_elevation: 10
 
+  cloud_cover_threshold: >-
+    {{ states(
+      'input_number.roof_shutters_cloud_cover_threshold'
+    ) | float(75) }}
+
   current_sun_azimuth: "{{ state_attr('sun.sun', 'azimuth') | float(0) }}"
 
   current_sun_elevation: "{{ state_attr('sun.sun', 'elevation') | float(0) }}"
+
+  current_cloud_cover: "{{ states('sensor.tomorrow_io_cloud_cover') | float(0) }}"

--- a/entities/template/binary_sensor/roof_terrace_window_in_direct_sun.yaml
+++ b/entities/template/binary_sensor/roof_terrace_window_in_direct_sun.yaml
@@ -1,25 +1,29 @@
 ---
-# Geometric + atmospheric check: vertical window faces ~260°; sun is "direct" when its azimuth
-# is within ±tolerance of that bearing, elevation is above a floor (low sun ignored), and cloud
-# cover is below the configured threshold (overcast skies block meaningful direct sunlight).
+# Geometric + atmospheric check: sun is "direct" when its azimuth is within ±tolerance of the
+# window bearing, elevation is above the minimum floor, and cloud cover is below the threshold.
+# All geometry parameters are configurable via input_numbers; cloud cover falls back to 0%
+# (clear-sky assumption) if the Tomorrow.io sensor is unavailable.
 name: Roof Terrace Window in Direct Sun
 
 unique_id: roof_terrace_window_in_direct_sun
 
 icon: mdi:weather-sunny
 
-# Avoid evaluating when sun.sun has no usable attributes (prevents bogus on/off from float defaults).
-# Cloud cover uses float(0) fallback so an unavailable forecast conservatively assumes clear sky.
+# Only unavailable when sun.sun itself is unavailable; input_numbers and cloud cover use fallbacks.
 availability: "{{ states('sun.sun') not in ['unavailable', 'unknown'] }}"
 
 state: >-
-  {# Compass bearing of the sun (0-360°, location and time already baked in). #}
   {% set sun_az = state_attr('sun.sun', 'azimuth') | float(0) %}
-  {# Angle above horizon; grazing rays below min_elevation are treated as not "direct". #}
   {% set sun_el = state_attr('sun.sun', 'elevation') | float(0) %}
-  {% set window_bearing = 260 %}
-  {% set azimuth_tolerance = 60 %}
-  {% set min_elevation = 10 %}
+  {% set window_bearing = states(
+    'input_number.roof_terrace_window_bearing'
+  ) | float(260) %}
+  {% set azimuth_tolerance = states(
+    'input_number.roof_terrace_window_azimuth_tolerance'
+  ) | float(60) %}
+  {% set min_elevation = states(
+    'input_number.roof_terrace_window_min_elevation'
+  ) | float(10) %}
   {# Smallest signed angle sun_az → window_bearing; % wraps at 360° so ±180° is the max step. #}
   {% set signed_diff = ((sun_az - window_bearing + 180) % 360) - 180 %}
   {# Cloud cover: unavailable sensor defaults to 0% (clear sky) — conservative/safe assumption. #}
@@ -27,16 +31,17 @@ state: >-
   {% set cloud_t = states(
     'input_number.roof_shutters_cloud_cover_threshold'
   ) | float(75) %}
-  {# ON when sun is geometrically in front of the window and sky is sufficiently clear. #}
   {{ (signed_diff | abs <= azimuth_tolerance) and (sun_el >= min_elevation) and (cloud < cloud_t) }}
 
-# Static thresholds for tuning; dynamic sun/cloud values mirror live data for dashboards/debug.
 attributes:
-  window_bearing: 260
+  window_bearing: >-
+    {{ states('input_number.roof_terrace_window_bearing') | float(260) }}
 
-  azimuth_tolerance: 60
+  azimuth_tolerance: >-
+    {{ states('input_number.roof_terrace_window_azimuth_tolerance') | float(60) }}
 
-  min_elevation: 10
+  min_elevation: >-
+    {{ states('input_number.roof_terrace_window_min_elevation') | float(10) }}
 
   cloud_cover_threshold: >-
     {{ states(

--- a/entities/template/sensor/nature/sun_azimuth.yaml
+++ b/entities/template/sensor/nature/sun_azimuth.yaml
@@ -1,0 +1,12 @@
+---
+name: Sun Azimuth
+
+unique_id: sun_azimuth
+
+unit_of_measurement: "°"
+
+icon: mdi:compass
+
+availability: "{{ states('sun.sun') not in ['unavailable', 'unknown'] }}"
+
+state: "{{ state_attr('sun.sun', 'azimuth') | float(0) }}"

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4731,7 +4731,7 @@ File: [`input_datetime/rain_flash_cooldown.yaml`](entities/input_datetime/rain_f
 
 ## Input Number
 
-<details><summary><h3>Entities (129)</h3></summary>
+<details><summary><h3>Entities (130)</h3></summary>
 
 <details><summary><strong>Auto-Save Debit Transaction Percentage</strong></summary>
 
@@ -5882,6 +5882,18 @@ File: [`input_number/threshold/octopi_fan/octopi_fan_auto_on_threshold.yaml`](en
 - Unit Of Measurement: °C
 
 File: [`input_number/threshold/roof_shutters/roof_shutters_close_temperature_threshold.yaml`](entities/input_number/threshold/roof_shutters/roof_shutters_close_temperature_threshold.yaml)
+</details>
+
+<details><summary><strong>Roof Shutters: Cloud Cover Threshold</strong></summary>
+
+**Entity ID: `input_number.roof_shutters_cloud_cover_threshold`**
+
+- Max: 100
+- Min: 10
+- Mode: `box`
+- Unit Of Measurement: %
+
+File: [`input_number/threshold/roof_shutters/roof_shutters_cloud_cover_threshold.yaml`](entities/input_number/threshold/roof_shutters/roof_shutters_cloud_cover_threshold.yaml)
 </details>
 
 <details><summary><strong>Roof Shutters: Wind Speed Threshold</strong></summary>

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4731,7 +4731,7 @@ File: [`input_datetime/rain_flash_cooldown.yaml`](entities/input_datetime/rain_f
 
 ## Input Number
 
-<details><summary><h3>Entities (128)</h3></summary>
+<details><summary><h3>Entities (129)</h3></summary>
 
 <details><summary><strong>Auto-Save Debit Transaction Percentage</strong></summary>
 
@@ -5882,6 +5882,18 @@ File: [`input_number/threshold/octopi_fan/octopi_fan_auto_on_threshold.yaml`](en
 - Unit Of Measurement: °C
 
 File: [`input_number/threshold/roof_shutters/roof_shutters_close_temperature_threshold.yaml`](entities/input_number/threshold/roof_shutters/roof_shutters_close_temperature_threshold.yaml)
+</details>
+
+<details><summary><strong>Roof Shutters: Wind Speed Threshold</strong></summary>
+
+**Entity ID: `input_number.roof_shutters_wind_speed_threshold`**
+
+- Max: 20
+- Min: 1
+- Mode: `box`
+- Unit Of Measurement: m/s
+
+File: [`input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml`](entities/input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml)
 </details>
 
 <details><summary><strong>Vic's Office Fan: PM2.5 Threshold</strong></summary>

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4731,8 +4731,7 @@ File: [`input_datetime/rain_flash_cooldown.yaml`](entities/input_datetime/rain_f
 
 ## Input Number
 
-<details><summary><h3>Entities (133)</h3></summary>
-<details><summary><h3>Entities (129)</h3></summary>
+<details><summary><h3>Entities (134)</h3></summary>
 
 <details><summary><strong>Auto-Save Debit Transaction Percentage</strong></summary>
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5891,7 +5891,7 @@ File: [`input_number/threshold/roof_shutters/roof_shutters_close_temperature_thr
 - Max: 20
 - Min: 1
 - Mode: `box`
-- Unit Of Measurement: m/s
+- Unit Of Measurement: `mph`
 
 File: [`input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml`](entities/input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml)
 </details>

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4731,7 +4731,7 @@ File: [`input_datetime/rain_flash_cooldown.yaml`](entities/input_datetime/rain_f
 
 ## Input Number
 
-<details><summary><h3>Entities (130)</h3></summary>
+<details><summary><h3>Entities (133)</h3></summary>
 
 <details><summary><strong>Auto-Save Debit Transaction Percentage</strong></summary>
 
@@ -5906,6 +5906,40 @@ File: [`input_number/threshold/roof_shutters/roof_shutters_cloud_cover_threshold
 - Unit Of Measurement: `mph`
 
 File: [`input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml`](entities/input_number/threshold/roof_shutters/roof_shutters_wind_speed_threshold.yaml)
+</details>
+
+<details><summary><strong>Roof Terrace Window: Azimuth Tolerance</strong></summary>
+
+**Entity ID: `input_number.roof_terrace_window_azimuth_tolerance`**
+
+- Max: 90
+- Min: 5
+- Mode: `box`
+- Unit Of Measurement: °
+
+File: [`input_number/threshold/roof_shutters/roof_terrace_window_azimuth_tolerance.yaml`](entities/input_number/threshold/roof_shutters/roof_terrace_window_azimuth_tolerance.yaml)
+</details>
+
+<details><summary><strong>Roof Terrace Window: Bearing</strong></summary>
+
+**Entity ID: `input_number.roof_terrace_window_bearing`**
+
+- Max: 359
+- Mode: `box`
+- Unit Of Measurement: °
+
+File: [`input_number/threshold/roof_shutters/roof_terrace_window_bearing.yaml`](entities/input_number/threshold/roof_shutters/roof_terrace_window_bearing.yaml)
+</details>
+
+<details><summary><strong>Roof Terrace Window: Min Elevation</strong></summary>
+
+**Entity ID: `input_number.roof_terrace_window_min_elevation`**
+
+- Max: 45
+- Mode: `box`
+- Unit Of Measurement: °
+
+File: [`input_number/threshold/roof_shutters/roof_terrace_window_min_elevation.yaml`](entities/input_number/threshold/roof_shutters/roof_terrace_window_min_elevation.yaml)
 </details>
 
 <details><summary><strong>Vic's Office Fan: PM2.5 Threshold</strong></summary>
@@ -10371,7 +10405,7 @@ File: [`sql/mood/will_mood_streak.yaml`](entities/sql/mood/will_mood_streak.yaml
 
 ## Template
 
-<details><summary><h3>Entities (94)</h3></summary>
+<details><summary><h3>Entities (95)</h3></summary>
 
 <details><summary><strong>Bank Holiday</strong></summary>
 
@@ -10984,6 +11018,16 @@ File: [`template/sensor/hifi_system_media_metadata.yaml`](entities/template/sens
 - Unit Of Measurement: %
 
 File: [`template/sensor/lighting_modifier.yaml`](entities/template/sensor/lighting_modifier.yaml)
+</details>
+
+<details><summary><strong>Sun Azimuth</strong></summary>
+
+**Entity ID: `sensor.sun_azimuth`**
+
+- Icon: [`mdi:compass`](https://pictogrammers.com/library/mdi/icon/compass/)
+- Unit Of Measurement: °
+
+File: [`template/sensor/nature/sun_azimuth.yaml`](entities/template/sensor/nature/sun_azimuth.yaml)
 </details>
 
 <details><summary><strong>Sun Elevation</strong></summary>


### PR DESCRIPTION


---



- 347995a | Add wind speed protection for roof shutters
- 3c46071 | Update wind speed source and units
- 7146d83 | Add cloud cover check to roof shutter logic
- 2ab1772 | Make roof terrace sun detection configurable
- eabee31 | [pre-commit.ci] auto fixes from pre-commit.com hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable wind speed threshold for roof shutter automation
  * Added configurable cloud cover threshold for window direct sun detection
  * Added adjustable window positioning parameters (bearing, azimuth tolerance, elevation)

* **Improvements**
  * Roof shutter automation now considers real-time wind conditions before opening
  * Direct sun detection now incorporates cloud cover data for improved window automation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->