### PR TITLE
Rename dining area spotlight group

### DIFF
--- a/entities/automation/remote/basement_remote/triple_left.yaml
+++ b/entities/automation/remote/basement_remote/triple_left.yaml
@@ -42,7 +42,7 @@ action:
       - alias: Set dining area spotlights and shelves to min(modifier, 20%)
         action: light.turn_on
         target:
-          entity_id: light.dining_area
+          entity_id: light.dining_area_spotlights
         data:
           brightness_pct: "{{ min(states('sensor.lighting_modifier') | int(70), 20) }}"
           transition: 1

--- a/entities/script/dining_area_set_lighting_based_on_occupancy.yaml
+++ b/entities/script/dining_area_set_lighting_based_on_occupancy.yaml
@@ -42,6 +42,6 @@ sequence:
 
           - action: light.turn_off
             target:
-              entity_id: light.dining_area
+              entity_id: light.dining_area_spotlights
             data:
               transition: 1


### PR DESCRIPTION


---



- 867b453 | Rename dining area spotlight group


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dining area spotlight control in automation routines. Spotlights are now targeted independently from the main dining area light during occupancy-based and remote control scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/worgarside/home-assistant/pull/2644)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->