### PR TITLE
ci: trigger auto-create PR workflow on any non-main branch push

### DIFF
--- a/.github/workflows/auto_create_pr.yml
+++ b/.github/workflows/auto_create_pr.yml
@@ -3,12 +3,8 @@ name: Auto-Create PR
 
 on:
   push:
-    branches:
-      - feature/*
-      - bugfix/*
-      - chore/*
-      - hotfix/*
-      - refactor/*
+    branches-ignore:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION


---



- 4026778 | ci: trigger auto-create PR workflow on any non-main branch push
