### PR TITLE
Add automation to notify when external IP sensor becomes unavailable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# Home Assistant Config — Claude Guidelines
+
+## Automation & Script Conventions
+
+### File layout
+- Automations live in `entities/automation/{entity_type}/{optional_device}/filename.yaml`
+- Notification automations go in `entities/automation/notification/`
+- One automation per file; file name matches the automation's purpose in `snake_case`
+
+### Naming
+| Field | Convention | Example |
+|-------|-----------|---------|
+| `id` | `snake_case` path | `notification_external_ip_unavailable` |
+| `alias` | `/path/to/automation` | `/notification/external-ip-unavailable` |
+| `notification_id` | `short_snake_case` | `external_ip_unavailable` |
+
+### Notifications
+- Use `script.notify_will` and/or `script.notify_vic` — never call `notify.*` services directly
+- Always set `continue_on_error: true` on notification action calls; they are non-critical and a transient failure must not abort the automation
+- Use `mdi:` icons via `mobile_notification_icon`
+- Set `sticky: true` for alerts that should persist until dismissed
+- Set `persistent: true` for critical alerts that survive "Clear All"
+- Provide a `notification_id` so notifications can be grouped or cleared
+
+### Example notification action block
+```yaml
+action:
+  - action: script.notify_will
+    continue_on_error: true
+    data:
+      title: "Something Happened"
+      message: "Details here"
+      notification_id: something_happened
+      mobile_notification_icon: mdi:alert
+      sticky: true
+```

--- a/entities/automation/notification/external_ip_unavailable.yaml
+++ b/entities/automation/notification/external_ip_unavailable.yaml
@@ -1,0 +1,24 @@
+---
+alias: /notification/external-ip-unavailable
+
+id: notification_external_ip_unavailable
+
+description: Notify Will when sensor.external_ip becomes unavailable
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: sensor.external_ip
+    to: unavailable
+    for:
+      minutes: 5
+
+action:
+  - action: script.notify_will
+    data:
+      title: "External IP Unavailable"
+      message: "The external IP sensor is unavailable"
+      notification_id: external_ip_unavailable
+      mobile_notification_icon: mdi:ip-network-outline
+      sticky: true

--- a/entities/automation/notification/external_ip_unavailable.yaml
+++ b/entities/automation/notification/external_ip_unavailable.yaml
@@ -16,6 +16,7 @@ trigger:
 
 action:
   - action: script.notify_will
+    continue_on_error: true
     data:
       title: "External IP Unavailable"
       message: "The external IP sensor is unavailable"

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## Automation
 
-<details><summary><h3>Entities (242)</h3></summary>
+<details><summary><h3>Entities (243)</h3></summary>
 
 <details><summary><code>/automation/auto-reload-complete</code></summary>
 
@@ -2054,6 +2054,19 @@ File: [`automation/notification/apollo_plt1b/ota_mode_on.yaml`](entities/automat
 - Mode: `single`
 
 File: [`automation/notification/apollo_plt1b/turn_ota_mode_off.yaml`](entities/automation/notification/apollo_plt1b/turn_ota_mode_off.yaml)
+</details>
+
+<details><summary><code>/notification/external-ip-unavailable</code></summary>
+
+**Entity ID: `automation.notification_external_ip_unavailable`**
+
+> Notify Will when sensor.external_ip becomes unavailable
+
+- Alias: /notification/external-ip-unavailable
+- ID: `notification_external_ip_unavailable`
+- Mode: `single`
+
+File: [`automation/notification/external_ip_unavailable.yaml`](entities/automation/notification/external_ip_unavailable.yaml)
 </details>
 
 <details><summary><code>/notification/prusa-i3/print-completed</code></summary>


### PR DESCRIPTION


---



- 9323edb | Add automation to notify when external IP sensor becomes unavailable
- f0cf3cc | [pre-commit.ci] auto fixes from pre-commit.com hooks
- 666ebd6 | Add continue_on_error to notify action; add CLAUDE.md with conventions
