### PR TITLE
Skip late-night bedroom door alert when Will is the only person home

### DIFF
--- a/entities/automation/binary_sensor/bedroom_door/late_night_open.yaml
+++ b/entities/automation/binary_sensor/bedroom_door/late_night_open.yaml
@@ -5,7 +5,7 @@ id: binary_sensor_bedroom_door_late_night_open
 
 description: >-
   Alert Will if the bedroom door is opened after 11pm when any of his devices have been
-  active in the past 30 minutes.
+  active in the past 30 minutes, unless he is the only person home.
 
 mode: single
 
@@ -21,6 +21,11 @@ condition:
   - condition: time
     after: "23:00:00"
     before: "06:00:00"
+
+  - alias: "Don't alert Will if he is the only person home"
+    condition: template
+    value_template: >-
+      {{ not (is_state('person.will', 'home') and states('zone.home') | int(0) <= 1) }}
 
   - condition: template
     value_template: >-

--- a/entities/automation/binary_sensor/bedroom_door/late_night_open.yaml
+++ b/entities/automation/binary_sensor/bedroom_door/late_night_open.yaml
@@ -25,7 +25,7 @@ condition:
   - alias: "Don't alert Will if he is the only person home"
     condition: template
     value_template: >-
-      {{ not (is_state('person.will', 'home') and states('zone.home') | int(0) <= 1) }}
+      {{ not (is_state('person.will', 'home') and states('zone.home') | int(2) <= 1) }}
 
   - condition: template
     value_template: >-

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -47,7 +47,7 @@ File: [`automation/binary_sensor/basement_presence/on.yaml`](entities/automation
 
 **Entity ID: `automation.binary_sensor_bedroom_door_late_night_open`**
 
-> Alert Will if the bedroom door is opened after 11pm when any of his devices have been active in the past 30 minutes.
+> Alert Will if the bedroom door is opened after 11pm when any of his devices have been active in the past 30 minutes, unless he is the only person home.
 
 - Alias: /binary-sensor/bedroom-door/late-night-open
 - ID: `binary_sensor_bedroom_door_late_night_open`


### PR DESCRIPTION


---



- d5a1d84 | Skip late-night bedroom door alert when Will is the only person home
- 473b656 | [pre-commit.ci] auto fixes from pre-commit.com hooks
- e8e0cb8 | Default to firing bedroom door alert when home count is unavailable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified late-night bedroom door alert to prevent notifications when home occupancy meets specific criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->