### PR TITLE
fix: correct sensor name typo in office desk config

### DIFF
--- a/entities/template/binary_sensor/office_desk_occupied.yaml
+++ b/entities/template/binary_sensor/office_desk_occupied.yaml
@@ -20,13 +20,13 @@ state: >-
   ) %}
 
   {{
-    states("binary_sensor.will_s_desk_occupancy") | bool(true) and
+    states("binary_sensor.will_s_office_occupancy") | bool(true) and
     (
       (
         states('binary_sensor.will_s_macbook_pro_docked') | bool(false) and
         mbp_active
       ) or (
-        states('binary_sensor.wills_work_macbook_pro_docked') | bool(false) and
+        states('binary_sensor.will_s_work_macbook_pro_docked') | bool(false) and
         work_mbp_active
       )
     )


### PR DESCRIPTION


---



- 9442e906 | fix: correct sensor name typo in office desk config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “Office Desk Occupied” sensor so it now uses the proper occupancy source.
  * Fixed the work MacBook docked check to reference the right device status, improving occupancy accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->